### PR TITLE
Set selectedoptions to empty array not null

### DIFF
--- a/components/select/multi-select.ts
+++ b/components/select/multi-select.ts
@@ -128,7 +128,7 @@ export class SuiMultiSelect<T, U> extends SuiSelectBase<T, U> implements AfterVi
                 }
             }
             if (values.length === 0) {
-                this.selectedOptions = null;
+                this.selectedOptions = [];
             }
         }
     }


### PR DESCRIPTION
In my last pull request, I introduced an error, when resetting the selectedOptions array in the multi-select component. I set the selectedOptions to 'null', which generates the error message "Cannot read property 'length' of null".
This pull request sets the selectedOptions to an empty array, so the error will be fixed and the labels will disappear from the multi-select as intended.