### PR TITLE
fix(select): Improved keyboard support

### DIFF
--- a/src/checkbox/checkbox.ts
+++ b/src/checkbox/checkbox.ts
@@ -1,4 +1,7 @@
-import { Component, Directive, Input, Output, HostListener, HostBinding, EventEmitter, forwardRef } from "@angular/core";
+import {
+    Component, Directive, Input, Output, HostListener, HostBinding,
+    EventEmitter, forwardRef, ViewChild, ElementRef
+} from "@angular/core";
 import { ICustomValueAccessorHost, customValueAccessorFactory, CustomValueAccessor } from "../util/custom-value-accessor";
 
 @Component({
@@ -10,7 +13,8 @@ import { ICustomValueAccessorHost, customValueAccessorFactory, CustomValueAccess
        [attr.name]="name"
        [attr.checked]="checkedAttribute"
        [attr.disabled]="isDisabledAttribute"
-       [(ngModel)]="isChecked">
+       [(ngModel)]="isChecked"
+       #checkbox>
 <label>
     <ng-content></ng-content>
 </label>
@@ -45,6 +49,9 @@ export class SuiCheckbox implements ICustomValueAccessorHost<boolean> {
         return this.isDisabled ? "disabled" : undefined;
     }
 
+    @ViewChild("checkbox")
+    private _checkboxElement:ElementRef;
+
     constructor() {
         this.isChecked = false;
         this.checkChange = new EventEmitter<boolean>();
@@ -59,6 +66,7 @@ export class SuiCheckbox implements ICustomValueAccessorHost<boolean> {
     public onClick():void {
         if (!this.isDisabled && !this.isReadonly) {
             this.toggle();
+            this.focusCheckbox();
         }
     }
 
@@ -69,6 +77,10 @@ export class SuiCheckbox implements ICustomValueAccessorHost<boolean> {
 
     public writeValue(value:boolean):void {
         this.isChecked = value;
+    }
+
+    private focusCheckbox():void {
+        this._checkboxElement.nativeElement.focus();
     }
 }
 

--- a/src/checkbox/radiobutton.ts
+++ b/src/checkbox/radiobutton.ts
@@ -1,4 +1,7 @@
-import { Component, Directive, Input, Output, HostListener, HostBinding, EventEmitter, forwardRef } from "@angular/core";
+import {
+    Component, Directive, Input, Output, HostListener, HostBinding,
+    EventEmitter, forwardRef, ViewChild, ElementRef
+} from "@angular/core";
 import { ICustomValueAccessorHost, customValueAccessorFactory, CustomValueAccessor } from "../util/custom-value-accessor";
 
 @Component({
@@ -11,7 +14,8 @@ import { ICustomValueAccessorHost, customValueAccessorFactory, CustomValueAccess
        [attr.checked]="checkedAttribute"
        [attr.disabled]="isDisabledAttribute"
        [ngModel]="isChecked"
-       (ngModel)="currentValue = value">
+       (ngModel)="currentValue = value"
+       #radio>
 <label>
     <ng-content></ng-content>
 </label>
@@ -44,6 +48,9 @@ export class SuiRadioButton<T> implements ICustomValueAccessorHost<T> {
     @Input()
     public isReadonly:boolean;
 
+    @ViewChild("radio")
+    private _radioElement:ElementRef;
+
     public get checkedAttribute():string | undefined {
         return this.isChecked ? "" : undefined;
     }
@@ -68,6 +75,7 @@ export class SuiRadioButton<T> implements ICustomValueAccessorHost<T> {
             this.currentValue = this.value;
             this.currentValueChange.emit(this.currentValue);
             this.update();
+            this.focusRadio();
         }
     }
 
@@ -78,6 +86,10 @@ export class SuiRadioButton<T> implements ICustomValueAccessorHost<T> {
     public writeValue(value:T):void {
         this.currentValue = value;
         this.update();
+    }
+
+    private focusRadio():void {
+        this._radioElement.nativeElement.focus();
     }
 }
 

--- a/src/dropdown/dropdown-menu.ts
+++ b/src/dropdown/dropdown-menu.ts
@@ -8,6 +8,7 @@ import { TransitionController } from "../transition/transition-controller";
 import { KeyCode, IAugmentedElement, HandledEvent } from "../util/util";
 // Polyfill for IE
 import "element-closest";
+import { TransitionDirection } from "../index";
 
 @Directive({
     // We must attach to every '.item' as Angular doesn't support > selectors.
@@ -82,7 +83,12 @@ export class SuiDropdownMenu extends SuiTransition implements AfterContentInit {
             if (isOpen !== previousIsOpen) {
                 // Only run transitions if the open state has changed.
                 this._transitionController.stopAll();
-                this._transitionController.animate(new Transition(this.menuTransition, this.menuTransitionDuration));
+                this._transitionController.animate(
+                    new Transition(
+                        this.menuTransition,
+                        this.menuTransitionDuration,
+                        TransitionDirection.Either,
+                        () => this._service.isAnimating = false));
             }
 
             if (!isOpen) {
@@ -160,7 +166,8 @@ export class SuiDropdownMenu extends SuiTransition implements AfterContentInit {
         if (this._service.isOpen && !this._service.isNested) {
             // Stop document events like scrolling while open.
             const target = e.target as Element;
-            if (!/input/i.test(target.tagName) || e.keyCode === KeyCode.Enter) {
+            if (!/input/i.test(target.tagName) &&
+                [KeyCode.Escape, KeyCode.Enter, KeyCode.Up, KeyCode.Down, KeyCode.Left, KeyCode.Right].find(kC => kC === e.keyCode)) {
                 e.preventDefault();
             }
 

--- a/src/dropdown/dropdown.service.ts
+++ b/src/dropdown/dropdown.service.ts
@@ -12,6 +12,8 @@ export const DropdownAutoCloseType = {
 export class DropdownService {
     // Open state of the dropdown
     public isOpen:boolean;
+    // Animating state of the dropdown.
+    public isAnimating:boolean;
     // Emitter for when dropdown open state changes.
     public isOpenChange:EventEmitter<boolean>;
 
@@ -43,6 +45,7 @@ export class DropdownService {
         if (this.isOpen !== isOpen && !this.isDisabled) {
             // Only update the state if it has changed, and the dropdown isn't disabled.
             this.isOpen = !!isOpen;
+            this.isAnimating = true;
             // We must delay the emitting to avoid the 'changed after checked' Angular errors.
             this.delay(() => this.isOpenChange.emit(this.isOpen));
 

--- a/src/dropdown/dropdown.ts
+++ b/src/dropdown/dropdown.ts
@@ -37,9 +37,6 @@ export class SuiDropdown implements AfterContentInit {
         return this.service.isOpen && !this.service.isNested;
     }
 
-    // Tracks dropdown open state between `mousedown` and `click`.
-    private _isOpenOnMouseDown:boolean;
-
     @Input()
     public get isOpen():boolean {
         return this.service.isOpen;
@@ -105,6 +102,11 @@ export class SuiDropdown implements AfterContentInit {
         }
     }
 
+    @HostListener("focusout")
+    private onFocusOut():void {
+        this.externallyClose();
+    }
+
     @HostListener("keypress", ["$event"])
     public onKeypress(e:HandledEvent & KeyboardEvent):void {
         // Block the keyboard event from being fired on parent dropdowns.
@@ -118,19 +120,18 @@ export class SuiDropdown implements AfterContentInit {
         }
     }
 
-    @HostListener("document:mousedown", ["$event"])
-    public onDocumentMouseDown(e:MouseEvent):void {
-        this._isOpenOnMouseDown = this.isOpen;
-    }
-
     @HostListener("document:click", ["$event"])
     public onDocumentClick(e:MouseEvent):void {
-        if (!this._element.nativeElement.contains(e.target) && this._isOpenOnMouseDown) {
-            if (this.service.autoCloseMode === DropdownAutoCloseType.ItemClick ||
+        if (!this._element.nativeElement.contains(e.target) && this.isOpen && !this.service.isAnimating) {
+            this.externallyClose();
+        }
+    }
+
+    private externallyClose():void {
+        if (this.service.autoCloseMode === DropdownAutoCloseType.ItemClick ||
                 this.service.autoCloseMode === DropdownAutoCloseType.OutsideClick) {
                 // No need to reflect in parent since they are also bound to document.
-                this.service.setOpenState(false);
-            }
+            this.service.setOpenState(false);
         }
     }
 }

--- a/src/search/search.ts
+++ b/src/search/search.ts
@@ -155,10 +155,24 @@ export class SuiSearch<T> implements AfterViewInit, ICustomValueAccessorHost<T> 
     }
 
     public onClick(e:MouseEvent):void {
+        this.open();
+    }
+
+    @HostListener("focusin")
+    private onFocusIn():void {
+        this.open();
+    }
+
+    private open():void {
         if (this.searchService.query.length > 0) {
             // Only open on click when there is a query entered.
             this.dropdownService.setOpenState(true);
         }
+    }
+
+    @HostListener("focusout")
+    private onFocusOut():void {
+        this.dropdownService.setOpenState(false);
     }
 
     @HostListener("document:click", ["$event"])

--- a/src/select/select-base.ts
+++ b/src/select/select-base.ts
@@ -231,6 +231,20 @@ export abstract class SuiSelectBase<T, U> implements AfterContentInit {
         }
     }
 
+    @HostListener("document:keydown", ["$event"])
+    public onDocumentKeyDown(e:KeyboardEvent):void {
+        if (e.target === this._element.nativeElement &&
+            !this.dropdownService.isOpen &&
+            e.keyCode === KeyCode.Down) {
+
+            // Enables support for focussing and opening with the keyboard alone.
+            // Using directly because Renderer2 doesn't have invokeElementMethod method anymore.
+            this._element.nativeElement.click();
+
+            e.preventDefault();
+        }
+    }
+
     protected focusInput():void {
         if (this.isSearchable) {
             // Focusses the search input only when searchable.

--- a/src/select/select-base.ts
+++ b/src/select/select-base.ts
@@ -203,7 +203,7 @@ export abstract class SuiSelectBase<T, U> implements AfterContentInit {
 
     @HostListener("click", ["$event"])
     public onClick(e:HandledEvent):void {
-        if (!e.eventHandled) {
+        if (!e.eventHandled && !this.dropdownService.isAnimating) {
             e.eventHandled = true;
 
             // Immediately focus the search input whenever clicking on the select.
@@ -212,6 +212,16 @@ export abstract class SuiSelectBase<T, U> implements AfterContentInit {
             // If the dropdown is searchable, clicking should keep it open, otherwise we toggle the open state.
             this.dropdownService.setOpenState(this.isSearchable ? true : !this.dropdownService.isOpen);
         }
+    }
+
+    @HostListener("focusin")
+    private onFocusIn():void {
+        this.dropdownService.setOpenState(true);
+    }
+
+    @HostListener("focusout")
+    private onFocusOut():void {
+        this.dropdownService.setOpenState(false);
     }
 
     @HostListener("keypress", ["$event"])


### PR DESCRIPTION
Closes #128 

Adds support for tabbing between search, select & dropdown components. This means that they automatically open & close as they gain and lose focus.

Checkboxes now also gain focus (& focus styles) when clicked.