### PR TITLE
fix(modal): Changed ModalTemplate to be an abstract class

### DIFF
--- a/src/modules/modal/classes/modal-template.ts
+++ b/src/modules/modal/classes/modal-template.ts
@@ -2,4 +2,5 @@ import { TemplateRef } from "@angular/core";
 import { ModalControls } from "./modal-controls";
 
 // Shorthand for a modal template. Sets up ability to write: `<ng-template let-context let-modal="modal">...</ng-template>`
-export type ModalTemplate<T, U, V> = TemplateRef<{ $implicit:T; modal:ModalControls<U, V> }>;
+// We use an abstract class as ModalTemplate tends to be used within decorated properties, which means it needs to exist!
+export abstract class ModalTemplate<T, U, V> extends TemplateRef<{ $implicit:T; modal:ModalControls<U, V> }> {}


### PR DESCRIPTION
This stops it from being erased by Typescript, so when people use it in decorators it still exists. Closes #171