### PR TITLE
fix(select): When sui-select ngModel set undefined, reset selectedOption

### DIFF
--- a/src/modules/select/components/select.ts
+++ b/src/modules/select/components/select.ts
@@ -116,6 +116,9 @@ export class SuiSelect<T, U> extends SuiSelectBase<T, U> implements ICustomValue
                     this._writtenOption = value;
                 }
             }
+        } else {
+            this.selectedOption = undefined;
+            this.drawSelectedOption();
         }
     }
 


### PR DESCRIPTION
When `<sui-select>`  ngModel set to a `undefined` value, `<sui-select>` can not clear the selected value.
This fix for sometime we want to clear the selected value.

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/edcarroll/ng2-semantic-ui/blob/master/CONTRIBUTING.md#) guide.
 - [x] linted, built and tested the changes locally.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
