### PR TITLE
en-GB and en-US locales now use 12 hour format

### DIFF
--- a/demo/src/app/pages/behaviors/localization/localization.page.ts
+++ b/demo/src/app/pages/behaviors/localization/localization.page.ts
@@ -146,6 +146,9 @@ interface ILocaleValues {
         weekdays:string[], // Full day names
         weekdaysShort:string[], // Short day names (3 letters)
         weekdaysNarrow:string[], // Narrow day names (1/2 letters)
+        timesOfDay:string[]; // Full time of day names (2 values only)
+        timesOfDayUppercase:string[]; // Short uppercase time of day names (2 values only)
+        timesOfDayLowercase:string[]; // Short lowercase time of day names (2 values only)
         formats: {
             time:string, // Date display format for 'time' mode
             datetime:string, // Display format for 'datetime' mode

--- a/src/behaviors/localization/interfaces/datepicker-values.ts
+++ b/src/behaviors/localization/interfaces/datepicker-values.ts
@@ -1,5 +1,6 @@
 export type Septuple<T> = [T, T, T, T, T, T, T];
 export type Duodecuple<T> = [T, T, T, T, T, T, T, T, T, T, T, T];
+export type Pair<T> = [T, T];
 
 export interface IDatepickerFormatsLocaleValues {
     year:string;
@@ -15,6 +16,9 @@ export interface IDatepickerLocaleValues {
     weekdays:Septuple<string>;
     weekdaysShort:Septuple<string>;
     weekdaysNarrow:Septuple<string>;
+    timesOfDay:Pair<string>;
+    timesOfDayUppercase:Pair<string>;
+    timesOfDayLowercase:Pair<string>;
     firstDayOfWeek:number;
     formats:IDatepickerFormatsLocaleValues;
 }

--- a/src/behaviors/localization/locales/en-GB.ts
+++ b/src/behaviors/localization/locales/en-GB.ts
@@ -19,8 +19,8 @@ const enGB:ILocaleValues = {
             "S", "M", "T", "W", "T", "F", "S"
         ],
         formats: {
-            time: "HH:mm",
-            datetime: "D MMMM YYYY HH:mm",
+            time: "hh:mm aa",
+            datetime: "D MMMM YYYY hh:mm aa",
             date: "D MMMM YYYY",
             month: "MMMM YYYY",
             year: "YYYY"

--- a/src/behaviors/localization/locales/en-GB.ts
+++ b/src/behaviors/localization/locales/en-GB.ts
@@ -1,4 +1,3 @@
-
 import { ILocaleValues } from "../interfaces/values";
 
 const enGB:ILocaleValues = {
@@ -17,6 +16,15 @@ const enGB:ILocaleValues = {
         ],
         weekdaysNarrow: [
             "S", "M", "T", "W", "T", "F", "S"
+        ],
+        timesOfDay: [
+            "a.m.", "p.m."
+        ],
+        timesOfDayUppercase: [
+            "AM", "PM"
+        ],
+        timesOfDayLowercase: [
+            "am", "pm"
         ],
         formats: {
             time: "hh:mm aa",

--- a/src/behaviors/localization/locales/en-US.ts
+++ b/src/behaviors/localization/locales/en-US.ts
@@ -4,8 +4,8 @@ const enUS:IPartialLocaleValues = {
     datepicker: {
         firstDayOfWeek: 0,
         formats: {
-            time: "HH:mm",
-            datetime: "MMMM D, YYYY HH:mm",
+            time: "hh:mm aa",
+            datetime: "MMMM D, YYYY hh:mm aa",
             date: "MMMM D, YYYY",
             month: "MMMM YYYY",
             year: "YYYY"

--- a/src/behaviors/localization/locales/he.ts
+++ b/src/behaviors/localization/locales/he.ts
@@ -2,9 +2,9 @@
  * locale : Hebrew (he)
  * author : David limkys : https://github.com/gotenxds
  */
-import { ILocaleValues } from "../interfaces/values";
+import { IPartialLocaleValues } from "../interfaces/values";
 
-const he:ILocaleValues = {
+const he:IPartialLocaleValues = {
     datepicker: {
         months: [
             "ינואר", "פבואר", "מרץ", "אפריל", "מאי", "יוני", "יולי", "אוגוסט", "ספטמבר", "אוקטובר", "נובמבר", "דצמבר"

--- a/src/behaviors/localization/locales/it.ts
+++ b/src/behaviors/localization/locales/it.ts
@@ -3,9 +3,9 @@
  * author : Massimo Costa : https://github.com/mcosta74
  */
 
-import { ILocaleValues } from "../interfaces/values";
+import { IPartialLocaleValues } from "../interfaces/values";
 
-const it:ILocaleValues = {
+const it:IPartialLocaleValues = {
     datepicker: {
         months: [
             "Gennaio", "Febbraio", "Marzo", "Aprile", "Maggio", "Giugno", "Luglio", "Agosto", "Settembre", "Ottobre", "Novembre", "Dicembre"

--- a/src/behaviors/localization/locales/ru.ts
+++ b/src/behaviors/localization/locales/ru.ts
@@ -1,11 +1,11 @@
-import { ILocaleValues } from "../interfaces/values";
+import { IPartialLocaleValues } from "../interfaces/values";
 
 /**
  * locale : Russian (ru)
  * author : Maksim Moiseikin : https://github.com/maksim-m
  */
 
-const ru:ILocaleValues = {
+const ru:IPartialLocaleValues = {
     datepicker: {
         months: [
             "Январь", "Февраль", "Март", "Апрель", "Май", "Июнь", "Июль", "Август", "Сентябрь", "Октябрь", "Ноябрь", "Декабрь"

--- a/src/modules/datepicker/helpers/date-fns.ts
+++ b/src/modules/datepicker/helpers/date-fns.ts
@@ -29,8 +29,10 @@ interface IDateFnsCustomLocale {
     };
 }
 
-function buildLocalizeFn(values:IDateFnsLocaleValues, defaultType:string,
+function buildLocalizeFn(values:IDateFnsLocaleValues,
+                         defaultType:string,
                          indexCallback?:(oldIndex:number) => number):DateFnsHelper<number, string> {
+
     return (dirtyIndex:number, { type } = { type: defaultType }) => {
         const index = indexCallback ? indexCallback(dirtyIndex) : dirtyIndex;
         return values[type][index];

--- a/src/modules/datepicker/helpers/date-fns.ts
+++ b/src/modules/datepicker/helpers/date-fns.ts
@@ -13,20 +13,28 @@ interface IDateFnsCustomLocale {
         weekdays:DateFnsHelper<IDateFnsHelperOptions, string[]>;
         month:DateFnsHelper<number, string>;
         months:DateFnsHelper<IDateFnsHelperOptions, string[]>;
+        timeOfDay:DateFnsHelper<number, string>;
+        timesOfDay:DateFnsHelper<IDateFnsHelperOptions, string[]>;
     };
     match:{
         weekdays:DateFnsHelper<string, RegExpMatchArray | null>;
         weekday?:DateFnsHelper<RegExpMatchArray, number>;
         months:DateFnsHelper<string, RegExpMatchArray | null>;
         month?:DateFnsHelper<RegExpMatchArray, number>;
+        timesOfDay:DateFnsHelper<string, RegExpMatchArray | null>;
+        timeOfDay?:DateFnsHelper<RegExpMatchArray, number>;
     };
     options?:{
         weekStartsOn?:number;
     };
 }
 
-function buildLocalizeFn(values:IDateFnsLocaleValues, defaultType:string):DateFnsHelper<number, string> {
-    return (dirtyIndex, { type } = { type: defaultType }) => values[type][dirtyIndex];
+function buildLocalizeFn(values:IDateFnsLocaleValues, defaultType:string,
+                         indexCallback?:(oldIndex:number) => number):DateFnsHelper<number, string> {
+    return (dirtyIndex:number, { type } = { type: defaultType }) => {
+        const index = indexCallback ? indexCallback(dirtyIndex) : dirtyIndex;
+        return values[type][index];
+    };
 }
 
 function buildLocalizeArrayFn(values:IDateFnsLocaleValues, defaultType:string):DateFnsHelper<IDateFnsHelperOptions, string[]> {
@@ -70,6 +78,17 @@ export class DateFnsParser {
             short: locale.monthsShort
         };
 
+        const timeOfDayValues = {
+            long: locale.timesOfDay,
+            uppercase: locale.timesOfDayUppercase,
+            lowercase: locale.timesOfDayLowercase
+        };
+
+        const timeOfDayMatchValues = {
+            long: locale.timesOfDay,
+            short: locale.timesOfDayUppercase.concat(locale.timesOfDayLowercase)
+        };
+
         this._locale = defaultLocale as any;
         this._locale.localize = {
             ...this._locale.localize,
@@ -77,7 +96,11 @@ export class DateFnsParser {
                 weekday: buildLocalizeFn(weekdayValues, "long"),
                 weekdays: buildLocalizeArrayFn(weekdayValues, "long"),
                 month: buildLocalizeFn(monthValues, "long"),
-                months: buildLocalizeArrayFn(monthValues, "long")
+                months: buildLocalizeArrayFn(monthValues, "long"),
+                timeOfDay: buildLocalizeFn(timeOfDayValues, "long", (hours:number) => {
+                    return hours / 12 >= 1 ? 1 : 0;
+                }),
+                timesOfDay: buildLocalizeArrayFn(timeOfDayValues, "long")
             }
         };
         this._locale.match = {
@@ -86,7 +109,9 @@ export class DateFnsParser {
                 weekdays: buildMatchFn(weekdayValues, "long"),
                 weekday: buildParseFn(weekdayValues, "long"),
                 months: buildMatchFn(monthValues, "long"),
-                month: buildParseFn(monthValues, "long")
+                month: buildParseFn(monthValues, "long"),
+                timesOfDay:buildMatchFn(timeOfDayMatchValues, "long"),
+                timeOfDay:buildParseFn(timeOfDayMatchValues, "long")
             }
         };
     }


### PR DESCRIPTION
Original "HH:mm" (23:59) -> Now "hh:mm aa" (11:59 p.m.)

Before submitting a pull request, please make sure you have at least performed the following:

 - [X] read and followed the [CONTRIBUTING.md](https://github.com/edcarroll/ng2-semantic-ui/blob/master/CONTRIBUTING.md#) guide.
 - [X] linted, built and tested the changes locally.
 - [X] added/updated any applicable API documentation.
 - [X] added/updated any applicable demos.
