### PR TITLE
feat(datepicker) Popup now honors locale and pickerLocaleOverrides

### DIFF
--- a/src/behaviors/localization/locales/es.ts
+++ b/src/behaviors/localization/locales/es.ts
@@ -24,7 +24,7 @@ const es:IPartialLocaleValues = {
         ],
         formats: {
             time: "HH:mm",
-            datetime: "D MMMM [de] YYYY HH:mm",
+            datetime: "D [de] MMMM [de] YYYY HH:mm",
             date: "D [de] MMMM [de] YYYY",
             month: "MMMM [de] YYYY",
             year: "YYYY"

--- a/src/modules/datepicker/classes/calendar-mappings.ts
+++ b/src/modules/datepicker/classes/calendar-mappings.ts
@@ -69,7 +69,7 @@ export class DatetimeMappings extends CalendarMappings {
             [CalendarViewType.Month, CalendarViewType.Year],
             [CalendarViewType.Date, CalendarViewType.Month],
             [CalendarViewType.Hour, CalendarViewType.Date],
-            [CalendarViewType.Minute, CalendarViewType.Date]
+            [CalendarViewType.Minute, CalendarViewType.Hour]
         ]);
     }
 }

--- a/src/modules/datepicker/views/date-view.ts
+++ b/src/modules/datepicker/views/date-view.ts
@@ -58,7 +58,7 @@ export class SuiCalendarDateView extends CalendarView {
     }
 
     public get date():string {
-        return new DateParser("MMMM YYYY", this.service.localeValues).format(this.currentDate);
+        return new DateParser(this.service.localeValues.formats.month, this.service.localeValues).format(this.currentDate);
     }
 
     constructor() {

--- a/src/modules/datepicker/views/hour-view.ts
+++ b/src/modules/datepicker/views/hour-view.ts
@@ -1,5 +1,5 @@
 import { Component } from "@angular/core";
-import { Util, DatePrecision } from "../../../misc/util";
+import { DatePrecision } from "../../../misc/util";
 import { CalendarView, CalendarViewType } from "./calendar-view";
 import { CalendarItem } from "../directives/calendar-item";
 import { CalendarRangeService } from "../services/calendar-range.service";
@@ -7,7 +7,8 @@ import { DateParser } from "../classes/date-parser";
 
 export class CalendarRangeHourService extends CalendarRangeService {
     public configureItem(item:CalendarItem, baseDate:Date):void {
-        item.humanReadable = `${Util.String.padLeft(item.date.getHours().toString(), 2, "0")}:00`;
+        const customFormat:string = this.service.localeValues.formats.time.replace(/m/g, "0");
+        item.humanReadable = new DateParser(customFormat, this.service.localeValues).format(item.date);
         item.isOutsideRange = false;
         item.isToday = false;
     }
@@ -43,8 +44,9 @@ export class CalendarRangeHourService extends CalendarRangeService {
 `
 })
 export class SuiCalendarHourView extends CalendarView {
+
     public get date():string {
-        return new DateParser("MMMM D, YYYY", this.service.localeValues).format(this.currentDate);
+        return new DateParser(this.service.localeValues.formats.date, this.service.localeValues).format(this.currentDate);
     }
 
     constructor() {

--- a/src/modules/datepicker/views/hour-view.ts
+++ b/src/modules/datepicker/views/hour-view.ts
@@ -7,7 +7,8 @@ import { DateParser } from "../classes/date-parser";
 
 export class CalendarRangeHourService extends CalendarRangeService {
     public configureItem(item:CalendarItem, baseDate:Date):void {
-        const customFormat:string = this.service.localeValues.formats.time.replace(/m/g, "0");
+        // Set minutes and seconds to 0
+        const customFormat:string = this.service.localeValues.formats.time.replace(/[ms]/g, "0");
         item.humanReadable = new DateParser(customFormat, this.service.localeValues).format(item.date);
         item.isOutsideRange = false;
         item.isToday = false;

--- a/src/modules/datepicker/views/minute-view.ts
+++ b/src/modules/datepicker/views/minute-view.ts
@@ -18,10 +18,7 @@ export class CalendarRangeMinuteService extends CalendarRangeService {
     }
 
     public configureItem(item:CalendarItem, baseDate:Date):void {
-        const hs = Util.String.padLeft(item.date.getHours().toString(), 2, "0");
-        const ms = Util.String.padLeft(item.date.getMinutes().toString(), 2, "0");
-
-        item.humanReadable = `${hs}:${ms}`;
+        item.humanReadable = new DateParser(this.service.localeValues.formats.time, this.service.localeValues).format(item.date);
         item.isOutsideRange = false;
         item.isToday = false;
     }
@@ -58,15 +55,13 @@ export class CalendarRangeMinuteService extends CalendarRangeService {
 })
 export class SuiCalendarMinuteView extends CalendarView {
     public get date():string {
-        const [time, date] = new DateParser("HH:00|MMMM D, YYYY", this.service.localeValues)
-            .format(this.currentDate)
-            .split("|");
-
         if (this.service.config.mode !== CalendarMode.TimeOnly) {
-            return `${date} ${time}`;
+            const dateTimeFormat:string = this.service.localeValues.formats.datetime.replace(/m/g, "0");
+            return new DateParser(dateTimeFormat, this.service.localeValues).format(this.currentDate);
+        } else {
+            const timeFormat:string = this.service.localeValues.formats.time.replace(/m/g, "0");
+            return new DateParser(timeFormat, this.service.localeValues).format(this.currentDate);
         }
-
-        return time;
     }
 
     constructor() {

--- a/src/modules/datepicker/views/minute-view.ts
+++ b/src/modules/datepicker/views/minute-view.ts
@@ -56,10 +56,12 @@ export class CalendarRangeMinuteService extends CalendarRangeService {
 export class SuiCalendarMinuteView extends CalendarView {
     public get date():string {
         if (this.service.config.mode !== CalendarMode.TimeOnly) {
-            const dateTimeFormat:string = this.service.localeValues.formats.datetime.replace(/m/g, "0");
+            // Set minutes and seconds to 0
+            const dateTimeFormat:string = this.service.localeValues.formats.datetime.replace(/[ms]/g, "0");
             return new DateParser(dateTimeFormat, this.service.localeValues).format(this.currentDate);
         } else {
-            const timeFormat:string = this.service.localeValues.formats.time.replace(/m/g, "0");
+            // Set minutes and seconds to 0
+            const timeFormat:string = this.service.localeValues.formats.time.replace(/[ms]/g, "0");
             return new DateParser(timeFormat, this.service.localeValues).format(this.currentDate);
         }
     }

--- a/src/modules/datepicker/views/month-view.ts
+++ b/src/modules/datepicker/views/month-view.ts
@@ -43,7 +43,7 @@ export class CalendarRangeMonthService extends CalendarRangeService {
 })
 export class SuiCalendarMonthView extends CalendarView {
     public get year():string {
-        return new DateParser("YYYY", this.service.localeValues).format(this.currentDate);
+        return new DateParser(this.service.localeValues.formats.year, this.service.localeValues).format(this.currentDate);
     }
 
     constructor() {


### PR DESCRIPTION
- Datepicker popup items now respect locale format
- Fixed a bug in zoom calendar mapping for datetime datepicker
- Fixed 'es' locale for consistency

(*) Partially addresses #164

Before submitting a pull request, please make sure you have at least performed the following:

 - [X] read and followed the [CONTRIBUTING.md](https://github.com/edcarroll/ng2-semantic-ui/blob/master/CONTRIBUTING.md#) guide.
 - [X] linted, built and tested the changes locally.
 - [X] added/updated any applicable API documentation.
 - [X] added/updated any applicable demos.
