### PR TITLE
feat: Add hover trigger to select and dropdown

### DIFF
--- a/demo/src/app/pages/modules/dropdown/dropdown.page.html
+++ b/demo/src/app/pages/modules/dropdown/dropdown.page.html
@@ -35,7 +35,13 @@
         </div>
         <example-dropdown-menu result></example-dropdown-menu>
     </demo-example>
-
+    <demo-example [code]="exampleHoverTriggerTemplate">
+        <div info>
+            <h4 class="ui header">Hover Trigger</h4>
+            <p>Dropdowns can be triggered by hovering</p>
+        </div>
+        <example-dropdown-hover-trigger result></example-dropdown-hover-trigger>
+    </demo-example>
     <sui-message class="info" [isDismissable]="false">
         <div class="header">Selection Dropdowns</div>
         <p>

--- a/demo/src/app/pages/modules/dropdown/dropdown.page.ts
+++ b/demo/src/app/pages/modules/dropdown/dropdown.page.ts
@@ -136,6 +136,28 @@ const exampleMenuTemplate = `
 </div>
 `;
 
+const exampleHoverTriggerTemplate = `
+<p>You can hover to trigger the dropdown.</p>
+<div class="ui primary dropdown button" suiDropdown trigger="hover" [autoClose]="outside ? 'outsideClick' : 'itemClick'">
+    <div class="text">Menu</div>
+    <i class="dropdown icon"></i>
+    <div class="menu" suiDropdownMenu>
+        <div class="item">Item 1</div>
+        <div class="disabled item">Disabled Item</div>
+        <div class="item" suiDropdown>
+            <i class="dropdown icon"></i>
+            Nested
+            <div class="menu" suiDropdownMenu>
+                <div class="item">Sub-item 1</div>
+                <div class="item">Sub-item 2</div>
+            </div>
+        </div>
+        <div class="item">Item 4</div>
+    </div>
+</div>
+<sui-checkbox [(ngModel)]="outside != outside">Auto close on <code>outsideClick</code>?</sui-checkbox>
+`;
+
 @Component({
     selector: "demo-page-dropdown",
     templateUrl: "./dropdown.page.html"
@@ -154,15 +176,21 @@ export class DropdownPage {
                 {
                     name: "isDisabled",
                     type: "boolean",
-                    description: "Sets whether or not the dropdown is disabled",
+                    description: "Sets whether or not the dropdown is disabled.",
                     defaultValue: "false"
                 },
                 {
                     name: "autoClose",
                     type: "DropdownAutoCloseType",
-                    description: "Defines when the dropdown is closed." +
+                    description: "Defines when the dropdown is closed. " +
                                  "Options are: <code>itemClick</code>, <code>outsideClick</code> & <code>disabled</code>.",
                     defaultValue: "itemClick"
+                },
+                {
+                    name: "trigger",
+                    type: "SelectTrigger",
+                    description: "Specifies the trigger for the dropdown. Options are: <code>click</code> & <code>hover</code>.",
+                    defaultValue: "click"
                 }
             ],
             events: [
@@ -202,6 +230,7 @@ export class DropdownPage {
     public exampleStandardTemplate:string = exampleStandardTemplate;
     public exampleStyledTemplate:string = exampleStyledTemplate;
     public exampleMenuTemplate:string = exampleMenuTemplate;
+    public exampleHoverTriggerTemplate:string = exampleHoverTriggerTemplate;
 }
 
 @Component({
@@ -231,11 +260,20 @@ export class DropdownExampleStyled {}
 })
 export class DropdownExampleMenu {}
 
+@Component({
+    selector: "example-dropdown-hover-trigger",
+    template: exampleHoverTriggerTemplate
+})
+export class DropdownExampleHoverTrigger {
+    public outside:boolean = false;
+ }
+
 export const DropdownPageComponents = [
     DropdownPage,
 
     DropdownExampleFileMenu,
     DropdownExampleStandard,
     DropdownExampleStyled,
-    DropdownExampleMenu
+    DropdownExampleMenu,
+    DropdownExampleHoverTrigger
 ];

--- a/demo/src/app/pages/modules/dropdown/dropdown.page.ts
+++ b/demo/src/app/pages/modules/dropdown/dropdown.page.ts
@@ -266,7 +266,7 @@ export class DropdownExampleMenu {}
 })
 export class DropdownExampleHoverTrigger {
     public outside:boolean = false;
- }
+}
 
 export const DropdownPageComponents = [
     DropdownPage,

--- a/demo/src/app/pages/modules/select/select.page.html
+++ b/demo/src/app/pages/modules/select/select.page.html
@@ -49,7 +49,7 @@
         </div>
     </demo-example>
 
-     <demo-example [code]="exampleHoverTriggerTemplate">
+    <demo-example [code]="exampleHoverTriggerTemplate">
         <div info>
             <h4 class="ui header">Hover Trigger</h4>
             <p>A select can be triggered by hovering</p>

--- a/demo/src/app/pages/modules/select/select.page.html
+++ b/demo/src/app/pages/modules/select/select.page.html
@@ -49,6 +49,16 @@
         </div>
     </demo-example>
 
+     <demo-example [code]="exampleHoverTriggerTemplate">
+        <div info>
+            <h4 class="ui header">Hover Trigger</h4>
+            <p>A select can be triggered by hovering</p>
+        </div>
+        <div result>
+            <example-select-hover-trigger></example-select-hover-trigger>
+        </div>
+    </demo-example>
+
     <demo-example [code]="exampleTemplateTemplate">
         <div info>
             <h4 class="ui header">Templates & Formatters</h4>

--- a/demo/src/app/pages/modules/select/select.page.ts
+++ b/demo/src/app/pages/modules/select/select.page.ts
@@ -113,6 +113,17 @@ const exampleInMenuSearchTemplate = `
 </sui-multi-select>
 `;
 
+const exampleHoverTriggerTemplate = `
+<sui-select [(ngModel)]="selectedOption"
+                  [options]="options"
+                  labelField="name"
+                  class="selection"
+                  trigger="hover"
+                  #select>
+    <sui-select-option *ngFor="let o of select.filteredOptions" [value]="o"></sui-select-option>
+</sui-select>
+`;
+
 const exampleTemplateTemplate = `
 <div class="ui segments">
     <div class="ui segment">
@@ -259,6 +270,12 @@ export class SelectPage {
                     name: "localeOverrides",
                     type: "RecursivePartial<ISearchLocaleValues>",
                     description: "Overrides the values from the localization service."
+                },
+                {
+                    name: "trigger",
+                    type: "SelectTrigger",
+                    description: "Specifies the trigger for the select. Options are: <code>click</code> & <code>hover</code>",
+                    defaultValue: "click"
                 }
             ],
             events: [
@@ -376,6 +393,12 @@ export class SelectPage {
                     name: "localeOverrides",
                     type: "Partial<ISearchLocaleValues>",
                     description: "Overrides the values from the localization service."
+                },
+                {
+                    name: "trigger",
+                    type: "SelectTrigger",
+                    description: "Specifies the trigger for the select. Options are: <code>click</code> & <code>hover</code>",
+                    defaultValue: "click"
                 }
             ],
             events: [
@@ -409,6 +432,7 @@ export class SelectPage {
     public exampleStandardTemplate:string = exampleStandardTemplate;
     public exampleVariationsTemplate:string = exampleVariationsTemplate;
     public exampleInMenuSearchTemplate:string = exampleInMenuSearchTemplate;
+    public exampleHoverTriggerTemplate:string = exampleHoverTriggerTemplate;
     public exampleTemplateTemplate:string = exampleTemplateTemplate;
     public formatterCode:string = `
 public formatter(option:IOption, query?:string):string {
@@ -478,6 +502,15 @@ export class SelectExampleInMenuSearch {
 }
 
 @Component({
+    selector: "example-select-hover-trigger",
+    template: exampleHoverTriggerTemplate
+})
+export class SelectExampleHoverTrigger {
+    public options:IOption[] = namedOptions;
+    public selectedOption:IOption;
+}
+
+@Component({
     selector: "example-select-template",
     template: exampleTemplateTemplate
 })
@@ -522,5 +555,6 @@ export const SelectPageComponents = [
     SelectExampleVariations,
     SelectExampleInMenuSearch,
     SelectExampleTemplate,
-    SelectExampleLookupSearch
+    SelectExampleLookupSearch,
+    SelectExampleHoverTrigger
 ];

--- a/src/modules/dropdown/directives/dropdown.ts
+++ b/src/modules/dropdown/directives/dropdown.ts
@@ -11,6 +11,7 @@ import { SelectTrigger } from "../../select/classes/select-config";
     selector: "[suiDropdown]"
 })
 export class SuiDropdown implements AfterContentInit {
+    private _hovering:boolean = false;
     public service:DropdownService;
 
     @ContentChild(SuiDropdownMenu)
@@ -144,17 +145,18 @@ export class SuiDropdown implements AfterContentInit {
         }
     }
 
-    private _hovering: boolean = false;
-
     @HostListener("mouseenter")
-    private onMouseEnter(): void {
+    private onMouseEnter():void {
         if (this.trigger === SelectTrigger.Hover) {
             this._hovering = true;
-            setTimeout(() => {
-                if (this._hovering) {
-                    this.service.setOpenState(true);
-                }
-            }, 100);
+            setTimeout(
+                () => {
+                    if (this._hovering) {
+                        this.service.setOpenState(true);
+                    }
+                },
+                100
+            );
         }
     }
 

--- a/src/modules/select/classes/select-base.ts
+++ b/src/modules/select/classes/select-base.ts
@@ -381,7 +381,7 @@ export abstract class SuiSelectBase<T, U> implements AfterContentInit, OnDestroy
 
     @HostListener("mouseenter")
     private onMouseEnter():void {
-       if (this.trigger === SelectTrigger.Hover && !this.dropdownService.isOpen && !this.dropdownService.isAnimating) {
+        if (this.trigger === SelectTrigger.Hover && !this.dropdownService.isOpen && !this.dropdownService.isAnimating) {
             this.dropdownService.setOpenState(true);
             this.focus();
         }

--- a/src/modules/select/classes/select-base.ts
+++ b/src/modules/select/classes/select-base.ts
@@ -18,7 +18,8 @@ export interface IOptionContext<T> extends ITemplateRefContext<T> {
 // We use generic type T to specify the type of the options we are working with,
 // and U to specify the type of the property of the option used as the value.
 export abstract class SuiSelectBase<T, U> implements AfterContentInit, OnDestroy {
-    public dropdownService:DropdownService;
+    private _hovering:boolean = false;
+    public dropdownService: DropdownService;
     public searchService:SearchService<T, U>;
 
     @ViewChild(SuiDropdownMenu)
@@ -382,13 +383,22 @@ export abstract class SuiSelectBase<T, U> implements AfterContentInit, OnDestroy
     @HostListener("mouseenter")
     private onMouseEnter():void {
         if (this.trigger === SelectTrigger.Hover && !this.dropdownService.isOpen && !this.dropdownService.isAnimating) {
-            this.dropdownService.setOpenState(true);
-            this.focus();
+            this._hovering = true;
+            setTimeout(
+                () => {
+                    if (this._hovering) {
+                        this.dropdownService.setOpenState(true);
+                        this.focus();
+                    }
+                },
+                100
+            );
         }
-    }
+     }
 
     @HostListener("mouseleave")
-    private onMouseLeave():void {
+    private onMouseLeave(): void {
+        this._hovering = false;
         if (this.trigger === SelectTrigger.Hover && this.dropdownService.isOpen) {
             this.dropdownService.setOpenState(false);
         }

--- a/src/modules/select/classes/select-base.ts
+++ b/src/modules/select/classes/select-base.ts
@@ -9,6 +9,7 @@ import { Util, ITemplateRefContext, HandledEvent, KeyCode, IFocusEvent } from ".
 import { ISelectLocaleValues, RecursivePartial, SuiLocalizationService } from "../../../behaviors/localization/index";
 import { SuiSelectOption } from "../components/select-option";
 import { SuiSelectSearch } from "../directives/select-search";
+import { SelectTrigger } from "./select-config";
 
 export interface IOptionContext<T> extends ITemplateRefContext<T> {
     query?:string;
@@ -222,6 +223,9 @@ export abstract class SuiSelectBase<T, U> implements AfterContentInit, OnDestroy
     @Input()
     public transitionDuration:number;
 
+    @Input()
+    public trigger:SelectTrigger;
+
     @Output("touched")
     public onTouched:EventEmitter<void>;
 
@@ -243,6 +247,7 @@ export abstract class SuiSelectBase<T, U> implements AfterContentInit, OnDestroy
         this.onTouched = new EventEmitter<void>();
 
         this._selectClasses = true;
+        this.trigger = SelectTrigger.Click;
     }
 
     public ngAfterContentInit():void {
@@ -346,7 +351,7 @@ export abstract class SuiSelectBase<T, U> implements AfterContentInit, OnDestroy
 
     @HostListener("click", ["$event"])
     public onClick(e:HandledEvent):void {
-        if (!e.eventHandled && !this.dropdownService.isAnimating) {
+        if (this.trigger === SelectTrigger.Click && !e.eventHandled && !this.dropdownService.isAnimating) {
             e.eventHandled = true;
 
             // If the dropdown is searchable, clicking should keep it open, otherwise we toggle the open state.
@@ -371,6 +376,21 @@ export abstract class SuiSelectBase<T, U> implements AfterContentInit, OnDestroy
         if (!this._element.nativeElement.contains(e.relatedTarget)) {
             this.dropdownService.setOpenState(false);
             this.onTouched.emit();
+        }
+    }
+
+    @HostListener("mouseenter")
+    private onMouseEnter():void {
+       if (this.trigger === SelectTrigger.Hover && !this.dropdownService.isOpen && !this.dropdownService.isAnimating) {
+            this.dropdownService.setOpenState(true);
+            this.focus();
+        }
+    }
+
+    @HostListener("mouseleave")
+    private onMouseLeave():void {
+        if (this.trigger === SelectTrigger.Hover && this.dropdownService.isOpen) {
+            this.dropdownService.setOpenState(false);
         }
     }
 

--- a/src/modules/select/classes/select-config.ts
+++ b/src/modules/select/classes/select-config.ts
@@ -1,0 +1,6 @@
+export type SelectTrigger = "hover" | "click";
+
+export const SelectTrigger = {
+    Hover: "hover" as SelectTrigger,
+    Click: "click" as SelectTrigger
+};

--- a/src/modules/select/index.ts
+++ b/src/modules/select/index.ts
@@ -1,4 +1,5 @@
 export * from "./classes/select-base";
+export * from "./classes/select-config";
 
 export * from "./components/multi-select-label";
 export * from "./components/multi-select";


### PR DESCRIPTION
A new 'trigger' setting for select and dropdown which defaults to 'click', but also can be 'hover'.

Includes a 100ms hover delay. 