### PR TITLE
feat(select): Hugely simplify HTML select definitions

### DIFF
--- a/demo/src/app/pages/behaviors/localization/localization.page.ts
+++ b/demo/src/app/pages/behaviors/localization/localization.page.ts
@@ -15,7 +15,7 @@ const exampleTemplate = `
                     #lang>
 
             <sui-select-option *ngFor="let l of lang.availableOptions"
-                               [value]="l"></sui-select-option>
+                               [option]="l"></sui-select-option>
         </sui-select>
     </div>
     <div class="ui segment">
@@ -26,9 +26,9 @@ const exampleTemplate = `
     </div>
     <div class="ui segment">
         <sui-select class="fluid selection">
-            <sui-select-option value="Option 1"></sui-select-option>
-            <sui-select-option value="Option 2"></sui-select-option>
-            <sui-select-option value="Option 3"></sui-select-option>
+            <sui-select-option option="Option 1"></sui-select-option>
+            <sui-select-option option="Option 2"></sui-select-option>
+            <sui-select-option option="Option 3"></sui-select-option>
         </sui-select>
     </div>
 </div>

--- a/demo/src/app/pages/development/test/test.page.html
+++ b/demo/src/app/pages/development/test/test.page.html
@@ -7,6 +7,6 @@
 <demo-page-content>
     <h2 class="ui dividing header">Examples</h2>
     <div class="ui segment">
-        
+        <sui-select [options]="[1,2,3]"></sui-select>
     </div>
 </demo-page-content>

--- a/demo/src/app/pages/modules/datepicker/datepicker.page.ts
+++ b/demo/src/app/pages/modules/datepicker/datepicker.page.ts
@@ -18,7 +18,7 @@ const exampleStandardTemplate = `
     <div class="field">
         <label>Datepicker Mode</label>
         <sui-select class="selection" [(ngModel)]="mode" [options]="datepickerModes" #modes>
-            <sui-select-option *ngFor="let m of modes.availableOptions" [value]="m"></sui-select-option>
+            <sui-select-option *ngFor="let m of modes.filteredOptions" [option]="m"></sui-select-option>
         </sui-select>
     </div>
     <div class="field">

--- a/demo/src/app/pages/modules/modal/modal.page.ts
+++ b/demo/src/app/pages/modules/modal/modal.page.ts
@@ -44,7 +44,7 @@ const exampleComponentTemplate = `
 <div class="field">
     <label>Modal Size:</label>
     <sui-select class="selection" [(ngModel)]="size" [options]="availableSizes" #sizes>
-        <sui-select-option *ngFor="let s of sizes.availableOptions" [value]="s"></sui-select-option>
+        <sui-select-option *ngFor="let s of sizes.filteredOptions" [option]="s"></sui-select-option>
     </sui-select>
 </div>
 <button class="ui primary button" (click)="open()">Confirm?</button>

--- a/demo/src/app/pages/modules/popup/popup.page.html
+++ b/demo/src/app/pages/modules/popup/popup.page.html
@@ -40,7 +40,7 @@
             <example-popup-placement class="ui cards" [position]="position"></example-popup-placement>
             <br>
             <sui-select class="selection" [(ngModel)]="position" [options]="placements" [isSearchable]="true" #placementSelect>
-                <sui-select-option *ngFor="let p of placementSelect.availableOptions" [value]="p"></sui-select-option>
+                <sui-select-option *ngFor="let p of placementSelect.filteredOptions" [option]="p"></sui-select-option>
             </sui-select>
         </div>
     </demo-example>

--- a/demo/src/app/pages/modules/select/select.page.ts
+++ b/demo/src/app/pages/modules/select/select.page.ts
@@ -12,9 +12,6 @@ const exampleStandardTemplate = `
                     [isSearchable]="searchable"
                     [isDisabled]="disabled"
                     #select>
-            <sui-select-option *ngFor="let option of select.filteredOptions"
-                               [option]="option">
-            </sui-select-option>
         </sui-select>
     </div>
     <div class="ui segment">
@@ -27,9 +24,6 @@ const exampleStandardTemplate = `
                           [isDisabled]="disabled"
                           [hasLabels]="!hideLabels"
                           #multiSelect>
-            <sui-select-option *ngFor="let option of multiSelect.filteredOptions"
-                               [option]="option">
-            </sui-select-option>
         </sui-multi-select>
         <br><br>
         <sui-checkbox [(ngModel)]="hideLabels">Hide labels?</sui-checkbox>
@@ -85,7 +79,6 @@ const exampleVariationsTemplate = `
                 <i class="tags icon"></i>
                 Filter by tag
             </div>
-            <sui-select-option *ngFor="let o of filterSelect.filteredOptions" [option]="o"></sui-select-option>
         </sui-select>
     </div>
 </div>
@@ -108,7 +101,7 @@ const exampleInMenuSearchTemplate = `
         Options
     </div>
     <div class="scrolling menu">
-        <sui-select-option *ngFor="let o of select.filteredOptions" [option]="o"></sui-select-option>
+        <sui-select-options></sui-select-options>
     </div>
 </sui-multi-select>
 `;
@@ -128,7 +121,6 @@ const exampleTemplateTemplate = `
                     [optionTemplate]="optionTemplate"
                     [isSearchable]="true"
                     #templated>
-            <sui-select-option *ngFor="let o of templated.filteredOptions" [option]="o"></sui-select-option>
         </sui-select>
     </div>
     <div class="ui segment">
@@ -138,7 +130,6 @@ const exampleTemplateTemplate = `
                     [options]="options"
                     [optionFormatter]="formatter"
                     #formatted>
-            <sui-select-option *ngFor="let o of formatted.filteredOptions" [option]="o"></sui-select-option>
         </sui-select>
     </div>
     <div class="ui segment">
@@ -155,7 +146,6 @@ const exampleSearchLookupTemplate = `
             optionField="id"
             [isSearchable]="true"
             #searchSelect>
-    <sui-select-option *ngFor="let o of searchSelect.filteredOptions" [option]="o"></sui-select-option>
 </sui-select>
 <div class="ui segment">
     <p>Currently selected: {{ selectedOption | json }}</p>

--- a/demo/src/app/pages/modules/select/select.page.ts
+++ b/demo/src/app/pages/modules/select/select.page.ts
@@ -13,7 +13,7 @@ const exampleStandardTemplate = `
                     [isDisabled]="disabled"
                     #select>
             <sui-select-option *ngFor="let option of select.filteredOptions"
-                               [value]="option">
+                               [option]="option">
             </sui-select-option>
         </sui-select>
     </div>
@@ -28,7 +28,7 @@ const exampleStandardTemplate = `
                           [hasLabels]="!hideLabels"
                           #multiSelect>
             <sui-select-option *ngFor="let option of multiSelect.filteredOptions"
-                               [value]="option">
+                               [option]="option">
             </sui-select-option>
         </sui-multi-select>
         <br><br>
@@ -52,10 +52,10 @@ const exampleVariationsTemplate = `
     <div class="ui segment">
         <p><strong>Basic</strong></p>
         <sui-select placeholder="Choose">
-            <sui-select-option value="Option 1"></sui-select-option>
-            <sui-select-option value="Option 2"></sui-select-option>
-            <sui-select-option value="Option 3"></sui-select-option>
-            <sui-select-option value="Option 4"></sui-select-option>
+            <sui-select-option option="Option 1"></sui-select-option>
+            <sui-select-option option="Option 2"></sui-select-option>
+            <sui-select-option option="Option 3"></sui-select-option>
+            <sui-select-option option="Option 4"></sui-select-option>
         </sui-select>
     </div>
     <div class="ui segment">
@@ -66,9 +66,9 @@ const exampleVariationsTemplate = `
                 Trending repos
                 <sui-select class="inline" [(ngModel)]="selectedRange">
                     <div class="header">Adjust time span</div>
-                    <sui-select-option value="today"></sui-select-option>
-                    <sui-select-option value="this week"></sui-select-option>
-                    <sui-select-option value="this month"></sui-select-option>
+                    <sui-select-option option="today"></sui-select-option>
+                    <sui-select-option option="this week"></sui-select-option>
+                    <sui-select-option option="this month"></sui-select-option>
                 </sui-select>
             </div>
         </h4>
@@ -85,7 +85,7 @@ const exampleVariationsTemplate = `
                 <i class="tags icon"></i>
                 Filter by tag
             </div>
-            <sui-select-option *ngFor="let o of filterSelect.filteredOptions" [value]="o"></sui-select-option>
+            <sui-select-option *ngFor="let o of filterSelect.filteredOptions" [option]="o"></sui-select-option>
         </sui-select>
     </div>
 </div>
@@ -108,7 +108,7 @@ const exampleInMenuSearchTemplate = `
         Options
     </div>
     <div class="scrolling menu">
-        <sui-select-option *ngFor="let o of select.filteredOptions" [value]="o"></sui-select-option>
+        <sui-select-option *ngFor="let o of select.filteredOptions" [option]="o"></sui-select-option>
     </div>
 </sui-multi-select>
 `;
@@ -128,7 +128,7 @@ const exampleTemplateTemplate = `
                     [optionTemplate]="optionTemplate"
                     [isSearchable]="true"
                     #templated>
-            <sui-select-option *ngFor="let o of templated.filteredOptions" [value]="o"></sui-select-option>
+            <sui-select-option *ngFor="let o of templated.filteredOptions" [option]="o"></sui-select-option>
         </sui-select>
     </div>
     <div class="ui segment">
@@ -138,7 +138,7 @@ const exampleTemplateTemplate = `
                     [options]="options"
                     [optionFormatter]="formatter"
                     #formatted>
-            <sui-select-option *ngFor="let o of formatted.filteredOptions" [value]="o"></sui-select-option>
+            <sui-select-option *ngFor="let o of formatted.filteredOptions" [option]="o"></sui-select-option>
         </sui-select>
     </div>
     <div class="ui segment">
@@ -152,10 +152,10 @@ const exampleSearchLookupTemplate = `
             [(ngModel)]="selectedOption"
             [optionsLookup]="optionsLookup"
             labelField="name"
-            valueField="id"
+            optionField="id"
             [isSearchable]="true"
             #searchSelect>
-    <sui-select-option *ngFor="let o of searchSelect.filteredOptions" [value]="o"></sui-select-option>
+    <sui-select-option *ngFor="let o of searchSelect.filteredOptions" [option]="o"></sui-select-option>
 </sui-select>
 <div class="ui segment">
     <p>Currently selected: {{ selectedOption | json }}</p>
@@ -257,7 +257,7 @@ export class SelectPage {
                 },
                 {
                     name: "localeOverrides",
-                    type: "RecursivePartial<ISearchLocaleValues>",
+                    type: "RecursivePartial<ISelectLocaleValues>",
                     description: "Overrides the values from the localization service."
                 }
             ],
@@ -374,7 +374,7 @@ export class SelectPage {
                 },
                 {
                     name: "localeOverrides",
-                    type: "Partial<ISearchLocaleValues>",
+                    type: "Partial<ISelectLocaleValues>",
                     description: "Overrides the values from the localization service."
                 }
             ],
@@ -395,9 +395,9 @@ export class SelectPage {
             selector: "<sui-select-option>",
             properties: [
                 {
-                    name: "value",
+                    name: "option",
                     type: "T",
-                    description: "Sets the value of the option.",
+                    description: "Sets the option the component represents.",
                     required: true
                 }
             ]

--- a/demo/src/app/pages/modules/transition/transition.page.ts
+++ b/demo/src/app/pages/modules/transition/transition.page.ts
@@ -7,7 +7,7 @@ const exampleStandardTemplate = `
     <img src="https://goo.gl/VUcnwx" class="ui image" [suiTransition]="transitionController">
 </div>
 <sui-select class="selection" [(ngModel)]="transitionName" [options]="transitions" [isSearchable]="true" #animSelect>
-    <sui-select-option *ngFor="let a of animSelect.availableOptions" [value]="a"></sui-select-option>
+    <sui-select-option *ngFor="let a of animSelect.filteredOptions" [option]="a"></sui-select-option>
 </sui-select>
 <button class="ui button" (click)="animate(transitionName)">Animate</button>
 `;

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "raw-loader": "0.5.1",
         "resolve": "1.3.3",
         "rsvp": "3.6.0",
-        "rxjs": "5.4.1",
+        "rxjs": "5.4.2",
         "sass-loader": "6.0.6",
         "script-loader": "0.7.0",
         "semver": "5.3.0",
@@ -427,7 +427,7 @@
     "aproba": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
-      "integrity": "sha1-RcZikJTeTpb2k+9+q3SuB5wkD8E=",
+      "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw==",
       "dev": true
     },
     "are-we-there-yet": {
@@ -4170,7 +4170,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
@@ -4203,7 +4203,7 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
     },
     "globby": {
@@ -5395,7 +5395,7 @@
     "istanbul-lib-coverage": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-      "integrity": "sha1-c7+5mIhSmUFck9OKPprfeEp3qdo=",
+      "integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q==",
       "dev": true
     },
     "istanbul-lib-hook": {
@@ -6249,7 +6249,7 @@
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -6426,7 +6426,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
@@ -8025,7 +8025,7 @@
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
+      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
         "is-number": "3.0.0",
@@ -8066,7 +8066,7 @@
     "randombytes": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
-      "integrity": "sha1-3ACaJGuNCaF3tLegrne8Vw9LG3k=",
+      "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
       "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
@@ -8758,9 +8758,9 @@
       }
     },
     "rxjs": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.4.1.tgz",
-      "integrity": "sha1-ti91fyeURdJloYpY+wpw3JDpFiY=",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.4.2.tgz",
+      "integrity": "sha1-KjI2/L8D31e64G/Wly/ZnlwI/Pc=",
       "requires": {
         "symbol-observable": "1.0.4"
       }
@@ -9470,7 +9470,7 @@
     "stream-http": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
-      "integrity": "sha1-QKBQ7I3DtTsz2ZCUFcAsC/Gr+60=",
+      "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
       "dev": true,
       "requires": {
         "builtin-status-codes": "3.0.0",
@@ -10059,7 +10059,7 @@
     "url-loader": {
       "version": "0.5.9",
       "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.5.9.tgz",
-      "integrity": "sha1-zI/qgse5Bud3cBklCGnlaemVwpU=",
+      "integrity": "sha512-B7QYFyvv+fOBqBVeefsxv6koWWtjmHaMFT6KZWti4KRw8YUD/hOU+3AECvXuzyVawIBx3z7zQRejXCDSO5kk1Q==",
       "dev": true,
       "requires": {
         "loader-utils": "1.1.0",
@@ -10269,7 +10269,7 @@
     "walk-sync": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.2.tgz",
-      "integrity": "sha1-SCcoCvxC0OA1NnxKTjHurA0Tb3U=",
+      "integrity": "sha512-FMB5VqpLqOCcqrzA9okZFc0wq0Qbmdm396qJxvQZhDpyu0W95G9JCmp74tx7iyYnyOcBtUuKJsgIKAqjozvmmQ==",
       "dev": true,
       "requires": {
         "ensure-posix-path": "1.0.2",
@@ -10634,7 +10634,7 @@
     "webpack-sources": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
-      "integrity": "sha1-xzVkNqTRMSO+LiQmoF0drZy+Zc8=",
+      "integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
       "dev": true,
       "requires": {
         "source-list-map": "2.0.0",
@@ -10644,7 +10644,7 @@
         "source-list-map": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
-          "integrity": "sha1-qqR0A/eyRakvvJfqCPJQ1gh+0IU=",
+          "integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
           "dev": true
         }
       }
@@ -10694,7 +10694,7 @@
     "wide-align": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha1-Vx4PGwYEY268DfwhsDObvjE0FxA=",
+      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "dev": true,
       "requires": {
         "string-width": "1.0.2"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "element-closest": "^2.0.2",
     "extend": "^3.0.1",
     "popper.js": "~1.10.6",
-    "rxjs": "^5.0.1"
+    "rxjs": "^5.4.2"
   },
   "devDependencies": {
     "@angular/common": "^4.3.1",

--- a/src/misc/util/services/component-factory.service.ts
+++ b/src/misc/util/services/component-factory.service.ts
@@ -34,8 +34,8 @@ export class SuiComponentFactory {
     }
 
     // Inserts the component into the specified view container.
-    public attachToView<T>(componentRef:ComponentRef<T>, viewContainer:ViewContainerRef):void {
-        viewContainer.insert(componentRef.hostView, 0);
+    public attachToView<T>(componentRef:ComponentRef<T>, viewContainer:ViewContainerRef, index:number = 0):void {
+        viewContainer.insert(componentRef.hostView, index);
     }
 
     // Inserts the component in the root application node.

--- a/src/modules/select/classes/select-base.ts
+++ b/src/modules/select/classes/select-base.ts
@@ -7,7 +7,7 @@ import { DropdownService, SuiDropdownMenu } from "../../dropdown";
 import { SearchService, LookupFn, FilterFn } from "../../search";
 import { Util, ITemplateRefContext, HandledEvent, KeyCode } from "../../../misc/util";
 import { ISelectLocaleValues, RecursivePartial, SuiLocalizationService } from "../../../behaviors/localization";
-import { SuiSelectOption } from "../components/select-option";
+import { SuiSelectOption, ISelectRenderedOption } from "../components/select-option";
 import { SuiSelectSearch } from "../directives/select-search";
 import { SuiSelectOptions } from "../components/select-options";
 
@@ -332,7 +332,7 @@ export abstract class SuiSelectBase<T, U> implements AfterContentInit, AfterView
         }
     }
 
-    protected initialiseRenderedOption(option:any):void {
+    protected initialiseRenderedOption(option:ISelectRenderedOption<T>):void {
         option.usesTemplate = !!this.optionTemplate;
         option.formatter = this.configuredFormatter;
 

--- a/src/modules/select/classes/select-base.ts
+++ b/src/modules/select/classes/select-base.ts
@@ -7,7 +7,7 @@ import { DropdownService, SuiDropdownMenu } from "../../dropdown";
 import { SearchService, LookupFn, FilterFn } from "../../search";
 import { Util, ITemplateRefContext, HandledEvent, KeyCode } from "../../../misc/util";
 import { ISelectLocaleValues, RecursivePartial, SuiLocalizationService } from "../../../behaviors/localization";
-import { SuiSelectOption, ISelectRenderedOption } from "../components/select-option";
+import { SuiSelectOption } from "../components/select-option";
 import { SuiSelectSearch } from "../directives/select-search";
 import { SuiSelectOptions } from "../components/select-options";
 
@@ -332,7 +332,7 @@ export abstract class SuiSelectBase<T, U> implements AfterContentInit, AfterView
         }
     }
 
-    protected initialiseRenderedOption(option:ISelectRenderedOption<T>):void {
+    protected initialiseRenderedOption(option:any):void {
         option.usesTemplate = !!this.optionTemplate;
         option.formatter = this.configuredFormatter;
 

--- a/src/modules/select/classes/select-base.ts
+++ b/src/modules/select/classes/select-base.ts
@@ -305,12 +305,12 @@ export abstract class SuiSelectBase<T, U> implements AfterContentInit {
             // Slightly delay initialisation to avoid change after checked errors. TODO - look into avoiding this!
             setTimeout(() => this.initialiseRenderedOption(ro));
 
-            this._renderedSubscriptions.push(ro.onSelected.subscribe(() => this.selectOption(ro.value)));
+            this._renderedSubscriptions.push(ro.onSelected.subscribe(() => this.selectOption(ro.option)));
         });
 
         // If no options have been provided, autogenerate them from the rendered ones.
         if (this.searchService.options.length === 0 && !this.searchService.optionsLookup) {
-            this.options = this._renderedOptions.map(ro => ro.value);
+            this.options = this._renderedOptions.map(ro => ro.option);
         }
     }
 
@@ -319,7 +319,7 @@ export abstract class SuiSelectBase<T, U> implements AfterContentInit {
         option.formatter = this.configuredFormatter;
 
         if (option.usesTemplate) {
-            this.drawTemplate(option.templateSibling, option.value);
+            this.drawTemplate(option.templateSibling, option.option);
         }
     }
 

--- a/src/modules/select/components/multi-select-label.ts
+++ b/src/modules/select/components/multi-select-label.ts
@@ -13,7 +13,7 @@ const templateRef = TemplateRef;
     selector: "sui-multi-select-label",
     template: `
 <span #templateSibling></span>
-<span *ngIf="!template" [innerHTML]="formatter(value)"></span>
+<span *ngIf="!template" [innerHTML]="formatter(option)"></span>
 <i class="delete icon" (click)="deselectOption($event)"></i>
 `
 })
@@ -27,7 +27,7 @@ export class SuiMultiSelectLabel<T> extends SuiTransition {
     private _transitionController:TransitionController;
 
     @Input()
-    public value:T;
+    public option:T;
 
     @Input()
     public query?:string;
@@ -49,7 +49,7 @@ export class SuiMultiSelectLabel<T> extends SuiTransition {
         this._template = template;
         if (this.template) {
             this.componentFactory.createView(this.templateSibling, this.template, {
-                $implicit: this.value,
+                $implicit: this.option,
                 query: this.query
             });
         }
@@ -82,7 +82,7 @@ export class SuiMultiSelectLabel<T> extends SuiTransition {
 
         this._transitionController.animate(
             new Transition("scale", 100, TransitionDirection.Out, () =>
-                this.onDeselected.emit(this.value)));
+                this.onDeselected.emit(this.option)));
     }
 
     @HostListener("click", ["$event"])

--- a/src/modules/select/components/multi-select-label.ts
+++ b/src/modules/select/components/multi-select-label.ts
@@ -36,7 +36,7 @@ export class SuiMultiSelectLabel<T> extends SuiTransition {
     public onDeselected:EventEmitter<T>;
 
     @Input()
-    public formatter:(obj:T) => string;
+    public formatter?:(obj:T) => string;
 
     private _template?:TemplateRef<IOptionContext<T>>;
 

--- a/src/modules/select/components/multi-select.ts
+++ b/src/modules/select/components/multi-select.ts
@@ -45,6 +45,7 @@ import { ISelectRenderedOption } from "./select-option";
      [menuAutoSelectFirst]="true">
 
     <ng-content></ng-content>
+    <sui-select-options></sui-select-options>
     <ng-container *ngIf="availableOptions.length == 0 ">
         <div *ngIf="!maxSelectedReached" class="message">{{ localeValues.noResultsMessage }}</div>
         <div *ngIf="maxSelectedReached" class="message">{{ maxSelectedMessage }}</div>

--- a/src/modules/select/components/multi-select.ts
+++ b/src/modules/select/components/multi-select.ts
@@ -2,6 +2,7 @@ import { Component, HostBinding, ElementRef, EventEmitter, Output, Input, Direct
 import { ICustomValueAccessorHost, KeyCode, customValueAccessorFactory, CustomValueAccessor } from "../../../misc/util";
 import { SuiLocalizationService } from "../../../behaviors/localization";
 import { SuiSelectBase } from "../classes/select-base";
+import { ISelectRenderedOption } from "./select-option";
 
 @Component({
     selector: "sui-multi-select",
@@ -11,7 +12,7 @@ import { SuiSelectBase } from "../classes/select-base";
 
 <ng-container *ngIf="hasLabels">
 <!-- Multi-select labels -->
-    <sui-multi-select-label *ngFor="let selected of selectedOptions"
+    <sui-multi-select-label *ngFor="let selected of selectedOptions;"
                             [option]="selected"
                             [query]="query"
                             [formatter]="configuredFormatter"
@@ -45,7 +46,7 @@ import { SuiSelectBase } from "../classes/select-base";
 
     <ng-content></ng-content>
     <sui-select-options></sui-select-options>
-    <ng-container *ngIf="filteredOptions.length == 0 ">
+    <ng-container *ngIf="availableOptions.length == 0 ">
         <div *ngIf="!maxSelectedReached" class="message">{{ localeValues.noResultsMessage }}</div>
         <div *ngIf="maxSelectedReached" class="message">{{ maxSelectedMessage }}</div>
     </ng-container>
@@ -158,7 +159,7 @@ export class SuiMultiSelect<T, U> extends SuiSelectBase<T, U> implements ICustom
         }
     }
 
-    protected initialiseRenderedOption(rendered:any):void {
+    protected initialiseRenderedOption(rendered:ISelectRenderedOption<T>):void {
         super.initialiseRenderedOption(rendered);
 
         // Boldens the item so it appears selected in the dropdown.

--- a/src/modules/select/components/multi-select.ts
+++ b/src/modules/select/components/multi-select.ts
@@ -2,7 +2,6 @@ import { Component, HostBinding, ElementRef, EventEmitter, Output, Input, Direct
 import { ICustomValueAccessorHost, KeyCode, customValueAccessorFactory, CustomValueAccessor } from "../../../misc/util";
 import { SuiLocalizationService } from "../../../behaviors/localization";
 import { SuiSelectBase } from "../classes/select-base";
-import { ISelectRenderedOption } from "./select-option";
 
 @Component({
     selector: "sui-multi-select",
@@ -12,7 +11,7 @@ import { ISelectRenderedOption } from "./select-option";
 
 <ng-container *ngIf="hasLabels">
 <!-- Multi-select labels -->
-    <sui-multi-select-label *ngFor="let selected of selectedOptions;"
+    <sui-multi-select-label *ngFor="let selected of selectedOptions"
                             [option]="selected"
                             [query]="query"
                             [formatter]="configuredFormatter"
@@ -46,7 +45,7 @@ import { ISelectRenderedOption } from "./select-option";
 
     <ng-content></ng-content>
     <sui-select-options></sui-select-options>
-    <ng-container *ngIf="availableOptions.length == 0 ">
+    <ng-container *ngIf="filteredOptions.length == 0 ">
         <div *ngIf="!maxSelectedReached" class="message">{{ localeValues.noResultsMessage }}</div>
         <div *ngIf="maxSelectedReached" class="message">{{ maxSelectedMessage }}</div>
     </ng-container>
@@ -159,7 +158,7 @@ export class SuiMultiSelect<T, U> extends SuiSelectBase<T, U> implements ICustom
         }
     }
 
-    protected initialiseRenderedOption(rendered:ISelectRenderedOption<T>):void {
+    protected initialiseRenderedOption(rendered:any):void {
         super.initialiseRenderedOption(rendered);
 
         // Boldens the item so it appears selected in the dropdown.

--- a/src/modules/select/components/multi-select.ts
+++ b/src/modules/select/components/multi-select.ts
@@ -13,7 +13,7 @@ import { ISelectRenderedOption } from "./select-option";
 <ng-container *ngIf="hasLabels">
 <!-- Multi-select labels -->
     <sui-multi-select-label *ngFor="let selected of selectedOptions;"
-                            [value]="selected"
+                            [option]="selected"
                             [query]="query"
                             [formatter]="configuredFormatter"
                             [template]="optionTemplate"
@@ -158,11 +158,11 @@ export class SuiMultiSelect<T, U> extends SuiSelectBase<T, U> implements ICustom
         }
     }
 
-    protected initialiseRenderedOption(option:ISelectRenderedOption<T>):void {
-        super.initialiseRenderedOption(option);
+    protected initialiseRenderedOption(rendered:ISelectRenderedOption<T>):void {
+        super.initialiseRenderedOption(rendered);
 
         // Boldens the item so it appears selected in the dropdown.
-        option.isActive = !this.hasLabels && this.selectedOptions.indexOf(option.value) !== -1;
+        rendered.isActive = !this.hasLabels && this.selectedOptions.indexOf(rendered.option) !== -1;
     }
 
     public selectOption(option:T):void {

--- a/src/modules/select/components/select-option.ts
+++ b/src/modules/select/components/select-option.ts
@@ -6,7 +6,7 @@ import { SuiDropdownMenuItem } from "../../dropdown";
 import { HandledEvent } from "../../../misc/util";
 
 export interface ISelectRenderedOption<T> {
-    value:T;
+    option:T;
     isActive?:boolean;
     formatter:(o:T) => string;
     usesTemplate:boolean;
@@ -26,7 +26,7 @@ export class SuiSelectOption<T> extends SuiDropdownMenuItem implements ISelectRe
     private _optionClasses:boolean;
 
     @Input()
-    public value:T;
+    public option:T;
 
     // Fires when the option is selected, whether by clicking or by keyboard.
     @Output()
@@ -39,7 +39,7 @@ export class SuiSelectOption<T> extends SuiDropdownMenuItem implements ISelectRe
 
     public set formatter(formatter:(obj:T) => string) {
         if (!this.usesTemplate) {
-            this.renderedText = formatter(this.value);
+            this.renderedText = formatter(this.option);
         } else {
             this.renderedText = undefined;
         }
@@ -70,6 +70,6 @@ export class SuiSelectOption<T> extends SuiDropdownMenuItem implements ISelectRe
     public onClick(e:HandledEvent):void {
         e.eventHandled = true;
 
-        setTimeout(() => this.onSelected.emit(this.value));
+        setTimeout(() => this.onSelected.emit(this.option));
     }
 }

--- a/src/modules/select/components/select-option.ts
+++ b/src/modules/select/components/select-option.ts
@@ -18,7 +18,16 @@ export interface ISelectRenderedOption<T> {
     template: `
 <span #templateSibling></span>
 <span [innerHTML]="renderedText"></span>
-`
+`,
+    styles: [`
+:host {
+    display: none !important;
+}
+
+:host-context(sui-select-options) {
+    display: block;
+}
+`]
 })
 export class SuiSelectOption<T> extends SuiDropdownMenuItem implements ISelectRenderedOption<T> {
     // Sets the Semantic UI classes on the host element.

--- a/src/modules/select/components/select-option.ts
+++ b/src/modules/select/components/select-option.ts
@@ -1,35 +1,19 @@
 import {
     Component, Input, HostBinding, HostListener, EventEmitter, ViewContainerRef,
-    ViewChild, Renderer2, ElementRef, Output, ChangeDetectorRef
+    ViewChild, Renderer2, ElementRef, Output, ChangeDetectorRef, TemplateRef
 } from "@angular/core";
 import { SuiDropdownMenuItem } from "../../dropdown";
-import { HandledEvent } from "../../../misc/util";
-
-export interface ISelectRenderedOption<T> {
-    option:T;
-    isActive?:boolean;
-    formatter:(o:T) => string;
-    usesTemplate:boolean;
-    templateSibling:ViewContainerRef;
-}
+import { HandledEvent, SuiComponentFactory } from "../../../misc/util";
+import { IOptionContext } from "../classes/select-base";
 
 @Component({
     selector: "sui-select-option",
     template: `
 <span #templateSibling></span>
-<span [innerHTML]="renderedText"></span>
-`,
-    styles: [`
-:host {
-    display: none !important;
-}
-
-:host-context(sui-select-options) {
-    display: block;
-}
-`]
+<span *ngIf="!template" [innerHTML]="formatter(option)"></span>
+`
 })
-export class SuiSelectOption<T> extends SuiDropdownMenuItem implements ISelectRenderedOption<T> {
+export class SuiSelectOption<T> extends SuiDropdownMenuItem {
     // Sets the Semantic UI classes on the host element.
     @HostBinding("class.item")
     private _optionClasses:boolean;
@@ -37,48 +21,55 @@ export class SuiSelectOption<T> extends SuiDropdownMenuItem implements ISelectRe
     @Input()
     public option:T;
 
-    // Fires when the option is selected, whether by clicking or by keyboard.
-    @Output()
-    public onSelected:EventEmitter<T>;
+    @Input()
+    public query?:string;
 
     @HostBinding("class.active")
     public isActive:boolean;
 
-    public renderedText?:string;
+    @Input()
+    public formatter?:(obj:T) => string;
 
-    public set formatter(formatter:(obj:T) => string) {
-        if (!this.usesTemplate) {
-            this.renderedText = formatter(this.option);
-        } else {
-            this.renderedText = undefined;
-        }
+    private _template?:TemplateRef<IOptionContext<T>>;
+
+    @Input()
+    public get template():TemplateRef<IOptionContext<T>> | undefined {
+        return this._template;
     }
 
-    public usesTemplate:boolean;
+    public set template(template:TemplateRef<IOptionContext<T>> | undefined) {
+        this._template = template;
+        if (this.template) {
+            this.componentFactory.createView(this.templateSibling, this.template, {
+                $implicit: this.option,
+                query: this.query
+            });
+        }
+    }
 
     // Placeholder to draw template beside.
     @ViewChild("templateSibling", { read: ViewContainerRef })
     public templateSibling:ViewContainerRef;
 
-    constructor(renderer:Renderer2, element:ElementRef) {
+    // Fires when the option is selected, whether by clicking or by keyboard.
+    @Output()
+    public onSelected:EventEmitter<T>;
+
+    constructor(renderer:Renderer2, element:ElementRef, public componentFactory:SuiComponentFactory) {
         // We inherit SuiDropdownMenuItem to automatically gain all keyboard navigation functionality.
         // This is not done via adding the .item class because it isn't supported by Angular.
         super(renderer, element);
 
-        this._optionClasses = true;
         this.isActive = false;
         this.onSelected = new EventEmitter<T>();
 
-        // By default we make this function return an empty string, for the brief moment when it isn't displaying the correct label.
-        this.formatter = o => "";
-
-        this.usesTemplate = false;
+        this._optionClasses = true;
     }
 
     @HostListener("click", ["$event"])
     public onClick(e:HandledEvent):void {
         e.eventHandled = true;
 
-        setTimeout(() => this.onSelected.emit(this.option));
+        this.onSelected.emit(this.option);
     }
 }

--- a/src/modules/select/components/select-options.ts
+++ b/src/modules/select/components/select-options.ts
@@ -1,39 +1,13 @@
-import { Component, Input, TemplateRef, EventEmitter, Output } from "@angular/core";
-import { IOptionContext } from "../classes/select-base";
-
-// See https://github.com/Microsoft/TypeScript/issues/13449.
-const templateRef = TemplateRef;
+import { Component, Input } from "@angular/core";
 
 @Component({
     selector: "sui-select-options",
-    template: `
-<sui-select-option *ngFor="let option of options"
-                   [option]="option"
-                   [query]="query"
-                   [formatter]="optionFormatter"
-                   [template]="optionTemplate"
-                   (selected)="onOptionSelected.emit($event)"></sui-select-option>
-`
+    template: `<sui-select-option *ngFor="let option of options" [option]="option"></sui-select-option>`
 })
 export class SuiSelectOptions<T> {
-    @Input()
     public options:T[];
-
-    @Input()
-    public query?:string;
-
-    @Input()
-    public optionFormatter?:(obj:T) => string;
-
-    @Input()
-    public optionTemplate?:TemplateRef<IOptionContext<T>>;
-
-    @Output("optionSelected")
-    public onOptionSelected:EventEmitter<T>;
 
     constructor() {
         this.options = [];
-
-        this.onOptionSelected = new EventEmitter<T>();
     }
 }

--- a/src/modules/select/components/select-options.ts
+++ b/src/modules/select/components/select-options.ts
@@ -2,12 +2,11 @@ import { Component, Input } from "@angular/core";
 
 @Component({
     selector: "sui-select-options",
-    template: `<sui-select-option *ngFor="let option of options" [option]="option"></sui-select-option>`
-})
-export class SuiSelectOptions<T> {
-    public options:T[];
-
-    constructor() {
-        this.options = [];
-    }
+    template: ``,
+    styles: [`
+:host {
+    display: none;
 }
+`]
+})
+export class SuiSelectOptions<T> {}

--- a/src/modules/select/components/select-options.ts
+++ b/src/modules/select/components/select-options.ts
@@ -1,0 +1,13 @@
+import { Component, Input } from "@angular/core";
+
+@Component({
+    selector: "sui-select-options",
+    template: `<sui-select-option *ngFor="let option of options" [option]="option"></sui-select-option>`
+})
+export class SuiSelectOptions<T> {
+    public options:T[];
+
+    constructor() {
+        this.options = [];
+    }
+}

--- a/src/modules/select/components/select-options.ts
+++ b/src/modules/select/components/select-options.ts
@@ -1,13 +1,39 @@
-import { Component, Input } from "@angular/core";
+import { Component, Input, TemplateRef, EventEmitter, Output } from "@angular/core";
+import { IOptionContext } from "../classes/select-base";
+
+// See https://github.com/Microsoft/TypeScript/issues/13449.
+const templateRef = TemplateRef;
 
 @Component({
     selector: "sui-select-options",
-    template: `<sui-select-option *ngFor="let option of options" [option]="option"></sui-select-option>`
+    template: `
+<sui-select-option *ngFor="let option of options"
+                   [option]="option"
+                   [query]="query"
+                   [formatter]="optionFormatter"
+                   [template]="optionTemplate"
+                   (selected)="onOptionSelected.emit($event)"></sui-select-option>
+`
 })
 export class SuiSelectOptions<T> {
+    @Input()
     public options:T[];
+
+    @Input()
+    public query?:string;
+
+    @Input()
+    public optionFormatter?:(obj:T) => string;
+
+    @Input()
+    public optionTemplate?:TemplateRef<IOptionContext<T>>;
+
+    @Output("optionSelected")
+    public onOptionSelected:EventEmitter<T>;
 
     constructor() {
         this.options = [];
+
+        this.onOptionSelected = new EventEmitter<T>();
     }
 }

--- a/src/modules/select/components/select.ts
+++ b/src/modules/select/components/select.ts
@@ -29,6 +29,7 @@ import { ISelectRenderedOption } from "./select-option";
      [menuAutoSelectFirst]="isSearchable">
 
     <ng-content></ng-content>
+    <sui-select-options></sui-select-options>
     <div *ngIf="isSearchable && availableOptions.length === 0" class="message">
         {{ localeValues.noResultsMessage }}
     </div>

--- a/src/modules/select/components/select.ts
+++ b/src/modules/select/components/select.ts
@@ -2,6 +2,7 @@ import { Component, ViewContainerRef, ViewChild, Output, EventEmitter, ElementRe
 import { ICustomValueAccessorHost, customValueAccessorFactory, CustomValueAccessor } from "../../../misc/util";
 import { SuiLocalizationService } from "../../../behaviors/localization";
 import { SuiSelectBase } from "../classes/select-base";
+import { ISelectRenderedOption } from "./select-option";
 
 @Component({
     selector: "sui-select",
@@ -28,14 +29,8 @@ import { SuiSelectBase } from "../classes/select-base";
      [menuAutoSelectFirst]="isSearchable">
 
     <ng-content></ng-content>
-    
-    <sui-select-options [options]="filteredOptions"
-                        [query]="query"
-                        [optionFormatter]="configuredFormatter"
-                        [optionTemplate]="optionTemplate"
-                        (optionSelected)="selectOption($event)"></sui-select-options>
-
-    <div *ngIf="isSearchable && filteredOptions.length === 0" class="message">
+    <sui-select-options></sui-select-options>
+    <div *ngIf="isSearchable && availableOptions.length === 0" class="message">
         {{ localeValues.noResultsMessage }}
     </div>
 </div>
@@ -128,7 +123,7 @@ export class SuiSelect<T, U> extends SuiSelectBase<T, U> implements ICustomValue
         }
     }
 
-    protected initialiseRenderedOption(rendered:any):void {
+    protected initialiseRenderedOption(rendered:ISelectRenderedOption<T>):void {
         super.initialiseRenderedOption(rendered);
 
         // Boldens the item so it appears selected in the dropdown.

--- a/src/modules/select/components/select.ts
+++ b/src/modules/select/components/select.ts
@@ -1,8 +1,8 @@
 import { Component, ViewContainerRef, ViewChild, Output, EventEmitter, ElementRef, Directive, Input } from "@angular/core";
-import { ICustomValueAccessorHost, customValueAccessorFactory, CustomValueAccessor } from "../../../misc/util";
+import { ICustomValueAccessorHost, customValueAccessorFactory, CustomValueAccessor, SuiComponentFactory } from "../../../misc/util";
 import { SuiLocalizationService } from "../../../behaviors/localization";
 import { SuiSelectBase } from "../classes/select-base";
-import { ISelectRenderedOption } from "./select-option";
+import { SuiSelectOption } from "./select-option";
 
 @Component({
     selector: "sui-select",
@@ -30,7 +30,7 @@ import { ISelectRenderedOption } from "./select-option";
 
     <ng-content></ng-content>
     <sui-select-options></sui-select-options>
-    <div *ngIf="isSearchable && availableOptions.length === 0" class="message">
+    <div *ngIf="isSearchable && (filteredOptions$ | async).length === 0" class="message">
         {{ localeValues.noResultsMessage }}
     </div>
 </div>
@@ -58,8 +58,11 @@ export class SuiSelect<T, U> extends SuiSelectBase<T, U> implements ICustomValue
         this._placeholder = placeholder;
     }
 
-    constructor(element:ElementRef, localizationService:SuiLocalizationService) {
-        super(element, localizationService);
+    constructor(element:ElementRef,
+                componentFactory:SuiComponentFactory,
+                localizationService:SuiLocalizationService) {
+
+        super(element, componentFactory, localizationService);
 
         this.selectedOptionChange = new EventEmitter<U>();
     }
@@ -123,8 +126,8 @@ export class SuiSelect<T, U> extends SuiSelectBase<T, U> implements ICustomValue
         }
     }
 
-    protected initialiseRenderedOption(rendered:ISelectRenderedOption<T>):void {
-        super.initialiseRenderedOption(rendered);
+    protected updateRenderedOption(rendered:SuiSelectOption<T>):void {
+        super.updateRenderedOption(rendered);
 
         // Boldens the item so it appears selected in the dropdown.
         rendered.isActive = rendered.option === this.selectedOption;
@@ -132,8 +135,8 @@ export class SuiSelect<T, U> extends SuiSelectBase<T, U> implements ICustomValue
 
     private drawSelectedOption():void {
         // Updates the active class on the newly selected option.
-        if (this._renderedOptions) {
-            this.onAvailableOptionsRendered();
+        if (this._manualOptions) {
+            this.onManualOptionsRendered();
         }
 
         if (this.selectedOption != undefined && this.optionTemplate) {

--- a/src/modules/select/components/select.ts
+++ b/src/modules/select/components/select.ts
@@ -2,7 +2,6 @@ import { Component, ViewContainerRef, ViewChild, Output, EventEmitter, ElementRe
 import { ICustomValueAccessorHost, customValueAccessorFactory, CustomValueAccessor } from "../../../misc/util";
 import { SuiLocalizationService } from "../../../behaviors/localization";
 import { SuiSelectBase } from "../classes/select-base";
-import { ISelectRenderedOption } from "./select-option";
 
 @Component({
     selector: "sui-select",
@@ -29,8 +28,14 @@ import { ISelectRenderedOption } from "./select-option";
      [menuAutoSelectFirst]="isSearchable">
 
     <ng-content></ng-content>
-    <sui-select-options></sui-select-options>
-    <div *ngIf="isSearchable && availableOptions.length === 0" class="message">
+    
+    <sui-select-options [options]="filteredOptions"
+                        [query]="query"
+                        [optionFormatter]="configuredFormatter"
+                        [optionTemplate]="optionTemplate"
+                        (optionSelected)="selectOption($event)"></sui-select-options>
+
+    <div *ngIf="isSearchable && filteredOptions.length === 0" class="message">
         {{ localeValues.noResultsMessage }}
     </div>
 </div>
@@ -123,7 +128,7 @@ export class SuiSelect<T, U> extends SuiSelectBase<T, U> implements ICustomValue
         }
     }
 
-    protected initialiseRenderedOption(rendered:ISelectRenderedOption<T>):void {
+    protected initialiseRenderedOption(rendered:any):void {
         super.initialiseRenderedOption(rendered);
 
         // Boldens the item so it appears selected in the dropdown.

--- a/src/modules/select/components/select.ts
+++ b/src/modules/select/components/select.ts
@@ -122,11 +122,11 @@ export class SuiSelect<T, U> extends SuiSelectBase<T, U> implements ICustomValue
         }
     }
 
-    protected initialiseRenderedOption(option:ISelectRenderedOption<T>):void {
-        super.initialiseRenderedOption(option);
+    protected initialiseRenderedOption(rendered:ISelectRenderedOption<T>):void {
+        super.initialiseRenderedOption(rendered);
 
         // Boldens the item so it appears selected in the dropdown.
-        option.isActive = option.value === this.selectedOption;
+        rendered.isActive = rendered.option === this.selectedOption;
     }
 
     private drawSelectedOption():void {

--- a/src/modules/select/select.module.ts
+++ b/src/modules/select/select.module.ts
@@ -37,6 +37,9 @@ import { SuiMultiSelectLabel } from "./components/multi-select-label";
         SuiSelectValueAccessor,
         SuiMultiSelect,
         SuiMultiSelectValueAccessor
+    ],
+    entryComponents: [
+        SuiSelectOption
     ]
 })
 export class SuiSelectModule {}

--- a/src/modules/select/select.module.ts
+++ b/src/modules/select/select.module.ts
@@ -6,6 +6,7 @@ import { SuiUtilityModule } from "../../misc/util";
 import { SuiLocalizationModule } from "../../behaviors/localization";
 import { SuiSelect, SuiSelectValueAccessor } from "./components/select";
 import { SuiSelectOption } from "./components/select-option";
+import { SuiSelectOptions } from "./components/select-options";
 import { SuiSelectSearch } from "./directives/select-search";
 import { SuiMultiSelect, SuiMultiSelectValueAccessor } from "./components/multi-select";
 import { SuiMultiSelectLabel } from "./components/multi-select-label";
@@ -21,6 +22,7 @@ import { SuiMultiSelectLabel } from "./components/multi-select-label";
     declarations: [
         SuiSelect,
         SuiSelectOption,
+        SuiSelectOptions,
         SuiSelectSearch,
         SuiSelectValueAccessor,
         SuiMultiSelect,
@@ -30,6 +32,7 @@ import { SuiMultiSelectLabel } from "./components/multi-select-label";
     exports: [
         SuiSelect,
         SuiSelectOption,
+        SuiSelectOptions,
         SuiSelectSearch,
         SuiSelectValueAccessor,
         SuiMultiSelect,


### PR DESCRIPTION
**PR is WIP**

This PR is aiming to address #134. It introduces a new way of defining a select, namely:

```html
<sui-select [options]="[1,2,3]"></sui-select>
```

It is no longer required for you to have to write the `*ngFor` manually.

However, this doesn't eliminate the ability to specify more complex markup within the select. For example, adding a header to a select is done like so:

```html
<sui-select [options]="[1,2,3]">
    <div class="header">
        <i class="tags icon"></i>
        Filter by tag
    </div>
</sui-select>
```

The results are rendered at the bottom.

However, if your markup is more complex still, you can manually specify the entry point for the options, like so:

```html
<sui-select [options]="[1,2,3]">
    <div class="ui icon search input">
        <i class="search icon"></i>
        <input suiSelectSearch type="text" placeholder="Search options...">
    </div>
    <div class="divider"></div>
    <div class="header">
        <i class="list icon"></i>
        Options
    </div>
    <div class="scrolling menu">
        <sui-select-options></sui-select-options>
    </div>
</sui-select>
```

Finally, if you want to manually specify the options, you can still do so by simply putting:

```html
<sui-select>
    <sui-select-option option="Option 1"></sui-select-option>
    <sui-select-option option="Option 2"></sui-select-option>
    <sui-select-option option="Option 3"></sui-select-option>
    <sui-select-option option="Option 4"></sui-select-option>
</sui-select>
```

Note that `value` has been renamed to `option`, as this makes it a bit more clear.