### PR TITLE
fix(modal): Fixed aggressive autofocus sometimes causing errors

### DIFF
--- a/src/modules/modal/components/modal.ts
+++ b/src/modules/modal/components/modal.ts
@@ -215,7 +215,8 @@ export class SuiModal<T, U> implements OnInit, AfterViewInit {
         // Focus any element with [autofocus] attribute.
         const autoFocus = element.querySelector("[autofocus]") as HTMLElement | null;
         if (autoFocus) {
-            autoFocus.focus();
+            // Autofocus after the browser has had time to process other event handlers.
+            setTimeout(() => autoFocus.focus(), 10);
             // Try to focus again when the modal has opened so that autofocus works in IE11.
             setTimeout(() => autoFocus.focus(), this.transitionDuration);
         }

--- a/src/modules/popup/components/popup.ts
+++ b/src/modules/popup/components/popup.ts
@@ -144,7 +144,8 @@ export class SuiPopup implements IPopup {
                     // Focus any element with [autofocus] attribute.
                     const autoFocus = this.elementRef.nativeElement.querySelector("[autofocus]") as HTMLElement | null;
                     if (autoFocus) {
-                        autoFocus.focus();
+                        // Autofocus after the browser has had time to process other event handlers.
+                        setTimeout(() => autoFocus.focus(), 10);
                         // Try to focus again when the modal has opened so that autofocus works in IE11.
                         setTimeout(() => autoFocus.focus(), this.config.transitionDuration);
                     }


### PR DESCRIPTION
This fixes an issue that ***occasionally*** occurs with things like dropdowns & modals - autofocus causes an early close in the dropdown which causes a changed after checked error...