### PR TITLE
fix: Minor bugs

### DIFF
--- a/demo/src/index.html
+++ b/demo/src/index.html
@@ -12,7 +12,7 @@
     <meta name="description" content="ng2-semantic-ui - Semantic UI Angular 2 Integrations">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.11/semantic.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.13/semantic.min.css">
     <!-- Calendar Module CSS -->
     <link rel="stylesheet" href="https://unpkg.com/semantic-ui-calendar/dist/calendar.min.css">
 

--- a/src/behaviors/localization/locales/en-AU.ts
+++ b/src/behaviors/localization/locales/en-AU.ts
@@ -1,4 +1,3 @@
-
 import { IPartialLocaleValues } from "../interfaces/values";
 
 /**

--- a/src/behaviors/localization/locales/en-GB.ts
+++ b/src/behaviors/localization/locales/en-GB.ts
@@ -27,8 +27,8 @@ const enGB:ILocaleValues = {
             "am", "pm"
         ],
         formats: {
-            time: "hh:mm aa",
-            datetime: "D MMMM YYYY hh:mm aa",
+            time: "h:mm A",
+            datetime: "D MMMM YYYY h:mm A",
             date: "D MMMM YYYY",
             month: "MMMM YYYY",
             year: "YYYY"

--- a/src/behaviors/localization/locales/en-US.ts
+++ b/src/behaviors/localization/locales/en-US.ts
@@ -4,8 +4,8 @@ const enUS:IPartialLocaleValues = {
     datepicker: {
         firstDayOfWeek: 0,
         formats: {
-            time: "hh:mm aa",
-            datetime: "MMMM D, YYYY hh:mm aa",
+            time: "h:mm A",
+            datetime: "MMMM D, YYYY h:mm A",
             date: "MMMM D, YYYY",
             month: "MMMM YYYY",
             year: "YYYY"

--- a/src/behaviors/localization/locales/he.ts
+++ b/src/behaviors/localization/locales/he.ts
@@ -1,8 +1,9 @@
+import { IPartialLocaleValues } from "../interfaces/values";
+
 /**
  * locale : Hebrew (he)
  * author : David limkys : https://github.com/gotenxds
  */
-import { IPartialLocaleValues } from "../interfaces/values";
 
 const he:IPartialLocaleValues = {
     datepicker: {

--- a/src/behaviors/localization/locales/it.ts
+++ b/src/behaviors/localization/locales/it.ts
@@ -1,9 +1,9 @@
+import { IPartialLocaleValues } from "../interfaces/values";
+
 /**
  * locale : Italian (it)
  * author : Massimo Costa : https://github.com/mcosta74
  */
-
-import { IPartialLocaleValues } from "../interfaces/values";
 
 const it:IPartialLocaleValues = {
     datepicker: {

--- a/src/modules/datepicker/components/calendar-view-title.ts
+++ b/src/modules/datepicker/components/calendar-view-title.ts
@@ -1,0 +1,36 @@
+import { Component, Input, EventEmitter, Output } from "@angular/core";
+import { CalendarRangeService } from "../services/calendar-range.service";
+
+@Component({
+    selector: "sui-calendar-view-title",
+    template: `
+<span class="title link" (click)="onZoomOut.emit()">
+    <ng-content></ng-content>
+</span>
+<span class="prev link" [class.disabled]="!ranges?.canMovePrevious" (click)="ranges?.movePrevious()">
+    <i class="chevron left icon"></i>
+</span>
+<span class="next link" [class.disabled]="!ranges?.canMoveNext" (click)="ranges?.moveNext()">
+    <i class="chevron right icon"></i>
+</span>
+`,
+    styles: [`
+.title.link {
+    display: inline-block;
+    margin-left: 2rem;
+    margin-right: 2rem;
+}
+`]
+})
+export class SuiCalendarViewTitle {
+
+    @Input()
+    public ranges:CalendarRangeService;
+
+    @Output("zoomOut")
+    public onZoomOut:EventEmitter<void>;
+
+    constructor() {
+        this.onZoomOut = new EventEmitter<void>();
+    }
+}

--- a/src/modules/datepicker/components/datepicker.ts
+++ b/src/modules/datepicker/components/datepicker.ts
@@ -1,4 +1,4 @@
-import { Component, HostBinding } from "@angular/core";
+import { Component, HostBinding, HostListener } from "@angular/core";
 import { CalendarService } from "./../services/calendar.service";
 import { DatetimeConfig } from "../classes/calendar-config";
 import { SuiLocalizationService } from "../../../behaviors/localization/index";
@@ -42,5 +42,10 @@ export class SuiDatepicker {
         this.service = new CalendarService(new DatetimeConfig(), localizationService.get().datepicker);
 
         this._calendarClasses = true;
+    }
+
+    @HostListener("mousedown", ["$event"])
+    public onMouseDown(e:MouseEvent):void {
+        e.preventDefault();
     }
 }

--- a/src/modules/datepicker/datepicker.module.ts
+++ b/src/modules/datepicker/datepicker.module.ts
@@ -4,6 +4,7 @@ import { FormsModule } from "@angular/forms";
 import { SuiPopupModule } from "../popup/index";
 import { SuiLocalizationModule } from "../../behaviors/localization/index";
 import { SuiUtilityModule } from "../../misc/util/index";
+import { SuiCalendarViewTitle } from "./components/calendar-view-title";
 import { SuiCalendarYearView } from "./views/year-view";
 import { SuiCalendarMonthView } from "./views/month-view";
 import { SuiCalendarItem } from "./directives/calendar-item";
@@ -28,6 +29,7 @@ import {
     declarations: [
         SuiCalendarItem,
 
+        SuiCalendarViewTitle,
         SuiCalendarYearView,
         SuiCalendarMonthView,
         SuiCalendarDateView,

--- a/src/modules/datepicker/index.ts
+++ b/src/modules/datepicker/index.ts
@@ -3,6 +3,7 @@ export * from "./classes/calendar-mappings";
 export * from "./classes/date-comparer";
 export * from "./classes/date-parser";
 
+export * from "./components/calendar-view-title";
 export * from "./components/datepicker";
 
 export * from "./directives/calendar-item";

--- a/src/modules/datepicker/views/date-view.ts
+++ b/src/modules/datepicker/views/date-view.ts
@@ -26,13 +26,9 @@ export class CalendarRangeDateService extends CalendarRangeService {
 <thead>
     <tr>
         <th colspan="7">
-            <span class="link" (click)="zoomOut()">{{ date }}</span>
-            <span class="prev link" [class.disabled]="!ranges.canMovePrevious" (click)="ranges.movePrevious()">
-                <i class="chevron left icon"></i>
-            </span>
-            <span class="next link" [class.disabled]="!ranges.canMoveNext" (click)="ranges.moveNext()">
-                <i class="chevron right icon"></i>
-            </span>
+            <sui-calendar-view-title [ranges]="ranges" (zoomOut)="zoomOut()">
+                {{ date }}
+            </sui-calendar-view-title>
         </th>
     </tr>
     <tr>

--- a/src/modules/datepicker/views/hour-view.ts
+++ b/src/modules/datepicker/views/hour-view.ts
@@ -11,7 +11,6 @@ export class CalendarRangeHourService extends CalendarRangeService {
         const customFormat:string = this.service.localeValues.formats.time.replace(/[ms]/g, "0");
         item.humanReadable = new DateParser(customFormat, this.service.localeValues).format(item.date);
         item.isOutsideRange = false;
-        item.isToday = false;
     }
 }
 
@@ -22,13 +21,9 @@ export class CalendarRangeHourService extends CalendarRangeService {
 <thead *ngIf="service.config.mode != 1">
     <tr>
         <th colspan="4">
-            <span class="link" (click)="zoomOut()">{{ date }}</span>
-            <span class="prev link" [class.disabled]="!ranges.canMovePrevious" (click)="ranges.movePrevious()">
-                <i class="chevron left icon"></i>
-            </span>
-            <span class="next link" [class.disabled]="!ranges.canMoveNext" (click)="ranges.moveNext()">
-                <i class="chevron right icon"></i>
-            </span>
+            <sui-calendar-view-title [ranges]="ranges" (zoomOut)="zoomOut()">
+                {{ date }}
+            </sui-calendar-view-title>
         </th>
     </tr>
 </thead>

--- a/src/modules/datepicker/views/minute-view.ts
+++ b/src/modules/datepicker/views/minute-view.ts
@@ -20,7 +20,6 @@ export class CalendarRangeMinuteService extends CalendarRangeService {
     public configureItem(item:CalendarItem, baseDate:Date):void {
         item.humanReadable = new DateParser(this.service.localeValues.formats.time, this.service.localeValues).format(item.date);
         item.isOutsideRange = false;
-        item.isToday = false;
     }
 }
 
@@ -31,13 +30,9 @@ export class CalendarRangeMinuteService extends CalendarRangeService {
 <thead>
     <tr>
         <th colspan="4">
-            <span class="link" (click)="zoomOut()">{{ date }}</span>
-            <span class="prev link" [class.disabled]="!ranges.canMovePrevious" (click)="ranges.movePrevious()">
-                <i class="chevron left icon"></i>
-            </span>
-            <span class="next link" [class.disabled]="!ranges.canMoveNext" (click)="ranges.moveNext()">
-                <i class="chevron right icon"></i>
-            </span>
+            <sui-calendar-view-title [ranges]="ranges" (zoomOut)="zoomOut()">
+                {{ date }}
+            </sui-calendar-view-title>
         </th>
     </tr>
 </thead>

--- a/src/modules/datepicker/views/month-view.ts
+++ b/src/modules/datepicker/views/month-view.ts
@@ -19,13 +19,9 @@ export class CalendarRangeMonthService extends CalendarRangeService {
 <thead>
     <tr>
         <th colspan="3">
-            <span class="link" (click)="zoomOut()">{{ year }}</span>
-            <span class="prev link" [class.disabled]="!ranges.canMovePrevious" (click)="ranges.movePrevious()">
-                <i class="chevron left icon"></i>
-            </span>
-            <span class="next link" [class.disabled]="!ranges.canMoveNext" (click)="ranges.moveNext()">
-                <i class="chevron right icon"></i>
-            </span>
+            <sui-calendar-view-title [ranges]="ranges" (zoomOut)="zoomOut()">
+                {{ year }}
+            </sui-calendar-view-title>
         </th>
     </tr>
 </thead>

--- a/src/modules/datepicker/views/year-view.ts
+++ b/src/modules/datepicker/views/year-view.ts
@@ -18,13 +18,9 @@ export class CalendarRangeYearService extends CalendarRangeService {
 <thead>
     <tr>
         <th colspan="3">
-            <span class="link" (click)="zoomOut()">{{ pad(decadeStart) }} - {{ pad(decadeStart + 10) }}</span>
-            <span class="prev link" [class.disabled]="!ranges.canMovePrevious" (click)="ranges.movePrevious()">
-                <i class="chevron left icon"></i>
-            </span>
-            <span class="next link" [class.disabled]="!ranges.canMoveNext" (click)="ranges.moveNext()">
-                <i class="chevron right icon"></i>
-            </span>
+            <sui-calendar-view-title [ranges]="ranges" (zoomOut)="zoomOut()">
+                {{ pad(decadeStart) }} - {{ pad(decadeStart + 10) }}
+            </sui-calendar-view-title>
         </th>
     </tr>
 </thead>

--- a/src/modules/dropdown/directives/dropdown-menu.ts
+++ b/src/modules/dropdown/directives/dropdown-menu.ts
@@ -180,35 +180,39 @@ export class SuiDropdownMenu extends SuiTransition implements AfterContentInit {
 
             switch (e.keyCode) {
                 // Escape : close the entire dropdown.
-                case KeyCode.Escape:
+                case KeyCode.Escape: {
                     this._service.setOpenState(false);
                     break;
+                }
                 // Down : select the next item below the current one, or the 1st if none selected.
                 case KeyCode.Down:
                 // Up : select the next item above the current one, or the 1st if none selected.
-                case KeyCode.Up:
+                case KeyCode.Up: {
                     this.selectedItems.pop();
                     this.selectedItems.push(selectedContainer.updateSelection(selected, e.keyCode));
                     // Prevent default regardless of whether we are in an input, to stop jumping to the start or end of the query string.
                     e.preventDefault();
                     break;
+                }
                 // Enter : if the item doesn't contain a nested dropdown, 'click' it. Otherwise, fall through to 'Right' action.
-                case KeyCode.Enter:
+                case KeyCode.Enter: {
                     if (selected && !selected.hasChildDropdown) {
                         selected.performClick();
                         break;
                     }
+                }
                     // falls through
                 // Right : if the selected item contains a nested dropdown, open the dropdown & select the 1st item.
-                case KeyCode.Right:
+                case KeyCode.Right: {
                     if (selected && selected.hasChildDropdown) {
                         selected.childDropdownMenu.service.setOpenState(true);
 
                         this.selectedItems.push(selected.childDropdownMenu.updateSelection(selected, e.keyCode));
                     }
                     break;
+                }
                 // Left : if the selected item is in a nested dropdown, close it and select the containing item.
-                case KeyCode.Left:
+                case KeyCode.Left: {
                     if (this.selectedItems.length >= 2) {
                         this.selectedItems.pop();
                         const [selectedParent] = this.selectedItems.slice(-1);
@@ -217,6 +221,7 @@ export class SuiDropdownMenu extends SuiTransition implements AfterContentInit {
                         selectedParent.isSelected = true;
                     }
                     break;
+                }
             }
         }
     }
@@ -271,9 +276,10 @@ export class SuiDropdownMenu extends SuiTransition implements AfterContentInit {
         if (newSelection) {
             // Set the selected status on the newly selected item.
             newSelection.isSelected = true;
-        }
 
-        this.scrollToItem(newSelection);
+            // Set the current scroll position to the location of the newly selected item.
+            this.scrollToItem(newSelection);
+        }
 
         return newSelection;
     }

--- a/src/modules/popup/classes/popup-component-controller.ts
+++ b/src/modules/popup/classes/popup-component-controller.ts
@@ -1,9 +1,9 @@
-import { ComponentRef, ElementRef, Type, Renderer2 } from "@angular/core";
+import { ComponentRef, ElementRef, Type, Renderer2, OnDestroy } from "@angular/core";
 import { SuiComponentFactory } from "../../../misc/util/index";
 import { SuiPopupController } from "./popup-controller";
 import { PopupConfig } from "./popup-config";
 
-export class SuiPopupComponentController<T> extends SuiPopupController {
+export class SuiPopupComponentController<T> extends SuiPopupController implements OnDestroy {
     // Stores reference to generated content component.
     private _contentComponentRef?:ComponentRef<T>;
 
@@ -36,5 +36,13 @@ export class SuiPopupComponentController<T> extends SuiPopupController {
         }
 
         super.open();
+    }
+
+    public ngOnDestroy():void {
+        if (this._contentComponentRef) {
+            this._contentComponentRef.destroy();
+        }
+
+        super.ngOnDestroy();
     }
 }

--- a/src/modules/popup/classes/popup-component-controller.ts
+++ b/src/modules/popup/classes/popup-component-controller.ts
@@ -30,8 +30,10 @@ export class SuiPopupComponentController<T> extends SuiPopupController {
     }
 
     public open():void {
-        this._contentComponentRef = this._componentFactory.createComponent(this._component as Type<T>);
-        this._componentFactory.attachToView(this._contentComponentRef, this.popup.templateSibling);
+        if (!this._contentComponentRef) {
+            this._contentComponentRef = this._componentFactory.createComponent(this._component as Type<T>);
+            this._componentFactory.attachToView(this._contentComponentRef, this.popup.templateSibling);
+        }
 
         super.open();
     }

--- a/src/modules/popup/classes/popup-component-controller.ts
+++ b/src/modules/popup/classes/popup-component-controller.ts
@@ -3,7 +3,7 @@ import { SuiComponentFactory } from "../../../misc/util/index";
 import { SuiPopupController } from "./popup-controller";
 import { PopupConfig } from "./popup-config";
 
-export class SuiPopupComponentController<T> extends SuiPopupController implements OnDestroy {
+export class SuiPopupComponentController<T> extends SuiPopupController {
     // Stores reference to generated content component.
     private _contentComponentRef?:ComponentRef<T>;
 
@@ -20,13 +20,6 @@ export class SuiPopupComponentController<T> extends SuiPopupController implement
                 config:PopupConfig) {
 
         super(renderer, element, componentFactory, config);
-
-        this.popup.onClose.subscribe(() => {
-            if (this._contentComponentRef) {
-                this._contentComponentRef.destroy();
-                this._contentComponentRef = undefined;
-            }
-        });
     }
 
     public open():void {
@@ -38,11 +31,12 @@ export class SuiPopupComponentController<T> extends SuiPopupController implement
         super.open();
     }
 
-    public ngOnDestroy():void {
+    protected cleanup():void {
+        super.cleanup();
+
         if (this._contentComponentRef) {
             this._contentComponentRef.destroy();
+            this._contentComponentRef = undefined;
         }
-
-        super.ngOnDestroy();
     }
 }

--- a/src/modules/popup/classes/popup-controller.ts
+++ b/src/modules/popup/classes/popup-controller.ts
@@ -38,13 +38,7 @@ export abstract class SuiPopupController implements IPopup, OnDestroy {
         this.popup.config = config;
 
         // When the popup is closed (onClose fires on animation complete),
-        this.popup.onClose.subscribe(() => {
-            this._componentRef.instance.positioningService.destroy();
-            this._componentFactory.detachFromApplication(this._componentRef);
-
-            // Remove the document click handler
-            this._documentListener();
-        });
+        this.popup.onClose.subscribe(() => this.cleanup());
     }
 
     public configure(config?:IPopupConfig):void {
@@ -175,9 +169,22 @@ export abstract class SuiPopupController implements IPopup, OnDestroy {
         }
     }
 
-    public ngOnDestroy():void {
+    protected cleanup():void {
         clearTimeout(this._openingTimeout);
+
+        if (this._componentRef.instance && this._componentRef.instance.positioningService) {
+            this._componentRef.instance.positioningService.destroy();
+        }
+
         this._componentFactory.detachFromApplication(this._componentRef);
-        this._componentRef.destroy();
+
+        if (this._documentListener) {
+            // Remove the document click handler
+            this._documentListener();
+        }
+    }
+
+    public ngOnDestroy():void {
+        this.cleanup();
     }
 }

--- a/src/modules/popup/components/popup.ts
+++ b/src/modules/popup/components/popup.ts
@@ -67,7 +67,7 @@ export class SuiPopup implements IPopup {
     // Keeps track of whether the popup is open internally.
     private _isOpen:boolean;
     // `setTimeout` timer pointer for cancelling popup close.
-    private _closingTimeout:number;
+    public closingTimeout:number;
 
     // Fires when the popup opens (and the animation is completed).
     public onOpen:EventEmitter<void>;
@@ -140,7 +140,7 @@ export class SuiPopup implements IPopup {
         // Only attempt to open if currently closed.
         if (!this.isOpen) {
             // Cancel the closing timer.
-            clearTimeout(this._closingTimeout);
+            clearTimeout(this.closingTimeout);
 
             // Cancel all other transitions, and initiate the opening transition.
             this.transitionController.stopAll();
@@ -183,9 +183,9 @@ export class SuiPopup implements IPopup {
                 new Transition(this.config.transition, this.config.transitionDuration, TransitionDirection.Out));
 
             // Cancel the closing timer.
-            clearTimeout(this._closingTimeout);
+            clearTimeout(this.closingTimeout);
             // Start the closing timer, that fires the `onClose` event after the transition duration number of milliseconds.
-            this._closingTimeout = window.setTimeout(() => this.onClose.emit(), this.config.transitionDuration);
+            this.closingTimeout = window.setTimeout(() => this.onClose.emit(), this.config.transitionDuration);
 
             // Finally, set the popup to be closed.
             this._isOpen = false;


### PR DESCRIPTION
* Update US & GB locales to use uppercase meridian time
* Adds support for long locale strings in the calendar views (titles no longer overflow)
* Fix datepicker focusout & destroyed view issues
* Fix component popup duplication glitch (rapid open & close)
* Ensure component popup is destroyed when component is destroyed
* Fixed error on keyboard navigation of empty dropdown
* Update to Semantic UI 2.2.13 (in the demo)