### PR TITLE
fix(pagination) Keep start page number

### DIFF
--- a/src/collections/pagination/components/pagination.spec.ts
+++ b/src/collections/pagination/components/pagination.spec.ts
@@ -196,4 +196,14 @@ describe("Pagination", () => {
         expect(pagination.pages.length).toBe(5);
         expect(pagination.hasNavigationLinks).toBe(true);
     });
+    it("should keep the start page number", () => {
+        comp.collectionSize = 100;
+        comp.pageSize = 10;
+        comp.maxSize = 5;
+        comp.currentPage = 5;
+
+        fixture.detectChanges();
+        expect(comp.currentPage).toBe(5);
+        expect(pagination.page).toBe(5);
+    });
 });

--- a/src/collections/pagination/components/pagination.ts
+++ b/src/collections/pagination/components/pagination.ts
@@ -65,7 +65,10 @@ export class SuiPagination implements OnChanges {
     public set maxSize(value:number | undefined) {
         this._maxSize = (value != undefined) ? Math.max(value, 1) : undefined;
     }
-
+    
+    @Input()
+    public pageSize:number;
+    
     @Input()
     public get collectionSize():number {
         return this._collectionSize;
@@ -75,9 +78,6 @@ export class SuiPagination implements OnChanges {
         this._collectionSize = Math.max(value, 0);
         this.pageCount = Math.max(1, Math.ceil(this._collectionSize / this.pageSize));
     }
-
-    @Input()
-    public pageSize:number;
 
     @Input()
     public get hasNavigationLinks():boolean {

--- a/src/collections/pagination/components/pagination.ts
+++ b/src/collections/pagination/components/pagination.ts
@@ -73,6 +73,7 @@ export class SuiPagination implements OnChanges {
 
     public set collectionSize(value:number) {
         this._collectionSize = Math.max(value, 0);
+        this.pageCount = Math.max(1, Math.ceil(this._collectionSize / this.pageSize));
     }
 
     @Input()
@@ -134,7 +135,6 @@ export class SuiPagination implements OnChanges {
     }
 
     public setPage(newPage:number):void {
-        this.pageCount = Math.max(1, Math.ceil(this._collectionSize / this.pageSize));
         const value:number = (Number.isInteger(newPage)) ? Math.min(Math.max(newPage, 1), this.pageCount) : 1;
         if (value !== this._page) {
             this._page = value;

--- a/src/collections/pagination/components/pagination.ts
+++ b/src/collections/pagination/components/pagination.ts
@@ -65,10 +65,10 @@ export class SuiPagination implements OnChanges {
     public set maxSize(value:number | undefined) {
         this._maxSize = (value != undefined) ? Math.max(value, 1) : undefined;
     }
-    
+
     @Input()
     public pageSize:number;
-    
+
     @Input()
     public get collectionSize():number {
         return this._collectionSize;

--- a/src/collections/pagination/components/pagination.ts
+++ b/src/collections/pagination/components/pagination.ts
@@ -134,6 +134,7 @@ export class SuiPagination implements OnChanges {
     }
 
     public setPage(newPage:number):void {
+        this.pageCount = Math.max(1, Math.ceil(this._collectionSize / this.pageSize));
         const value:number = (Number.isInteger(newPage)) ? Math.min(Math.max(newPage, 1), this.pageCount) : 1;
         if (value !== this._page) {
             this._page = value;


### PR DESCRIPTION
Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/edcarroll/ng2-semantic-ui/blob/master/CONTRIBUTING.md#) guide.
 - [x] linted, built and tested the changes locally.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.

Hey, Was having a problem with starting the pagination component on a different page number. 
This was because this.pageCount was set after page range checks. Meaning this line (137) always = 1. 
```js
const value:number = (Number.isInteger(newPage)) ? Math.min(Math.max(newPage, 1), this.pageCount) : 1;
```  