### PR TITLE
Added compareWith input for select

### DIFF
--- a/demo/src/app/pages/modules/select/select.page.ts
+++ b/demo/src/app/pages/modules/select/select.page.ts
@@ -198,6 +198,11 @@ export class SelectPage {
                                  "This must be defined as an arrow function in your class."
                 },
                 {
+                    name: "compareWith",
+                    type: "(o1:U, o2:U) => boolean",
+                    description: "A function to compare two value types, it will be called when searching for values in the options."
+                },
+                {
                     name: "labelField",
                     type: "string",
                     description: "Sets the property name that is used as a label for each option. " +

--- a/src/modules/select/classes/select-base.ts
+++ b/src/modules/select/classes/select-base.ts
@@ -30,6 +30,9 @@ export abstract class SuiSelectBase<T, U> implements AfterContentInit, OnDestroy
     // Keep track of all of the subscriptions to the selected events on the rendered options.
     private _renderedSubscriptions:Subscription[];
 
+    // Method used to compare the type of property of the option used as the value.
+    private _compareWith:(o1:U, o2:U) => boolean;
+
     // Sets the Semantic UI classes on the host element.
     @HostBinding("class.ui")
     @HostBinding("class.dropdown")
@@ -129,6 +132,13 @@ export abstract class SuiSelectBase<T, U> implements AfterContentInit, OnDestroy
             this.searchService.optionsLookup = lookup;
 
             this.optionsUpdateHook();
+        }
+    }
+
+    @Input()
+    public set compareWith(fn:(o1:U, o2:U) => boolean) {
+        if (fn) {
+            this._compareWith = fn;
         }
     }
 
@@ -331,6 +341,9 @@ export abstract class SuiSelectBase<T, U> implements AfterContentInit, OnDestroy
     public abstract selectOption(option:T):void;
 
     protected findOption(options:T[], value:U):T | undefined {
+        if (this._compareWith) {
+            return options.find(o => this._compareWith(value, this.valueGetter(o)));
+        }
         // Tries to find an option in options array
         return options.find(o => value === this.valueGetter(o));
     }


### PR DESCRIPTION
This function allows to add a comparison function for the option used as a value. It is called when searching for the option in the options array. If it is not defined, it defaults to a standard === comparison.

I haven't fully tested yet because I'm not quite sure that this is going in the right direction. If it seems to be correct, I'll update and add maybe an example.

Before submitting a pull request, please make sure you have at least performed the following:

 - [X] read and followed the [CONTRIBUTING.md](https://github.com/edcarroll/ng2-semantic-ui/blob/master/CONTRIBUTING.md#) guide.
 - [] linted, built and tested the changes locally.
 - [X] added/updated any applicable API documentation.
 - [ ] added/updated any applicable demos.
