### PR TITLE
search component added option inputValue, allows to set the value of input field without triggering a search

### DIFF
--- a/src/modules/search/components/search.ts
+++ b/src/modules/search/components/search.ts
@@ -54,6 +54,7 @@ export interface IResultContext<T> extends ITemplateRefContext<T> {
 export class SuiSearch<T> implements AfterViewInit, OnDestroy {
     public dropdownService:DropdownService;
     public searchService:SearchService<T, T>;
+    private _inputValue:any = false;
 
     @ViewChild(SuiDropdownMenu)
     private _menu:SuiDropdownMenu;
@@ -85,6 +86,12 @@ export class SuiSearch<T> implements AfterViewInit, OnDestroy {
         this._placeholder = placeholder;
     }
 
+    // Sets the input value text without triggering a search.
+    @Input()
+    public set inputValue(query:string) {
+        this._inputValue = (query == '' || query == null)?false:query;
+    }
+
     private _localeValues:ISearchLocaleValues;
 
     public localeOverrides:RecursivePartial<ISearchLocaleValues>;
@@ -94,10 +101,16 @@ export class SuiSearch<T> implements AfterViewInit, OnDestroy {
     }
 
     public get query():string {
-        return this.searchService.query;
+        if(this._inputValue){
+          return this._inputValue;
+        }
+        else{
+          return this.searchService.query;
+        }
     }
 
     public set query(query:string) {
+        this._inputValue = false;
         this.selectedResult = undefined;
         // Initialise a delayed search.
         this.searchService.updateQueryDelayed(query, () =>


### PR DESCRIPTION
search component added option inputValue, allows to set the value of input field without triggering a search input field without triggering a search, if input value changes a new search is made and the inputValue is ignored, usefull in forms where a search trigger a query to google maps and add a form group with the selected address, if the form is opened for editing the search field must show a formatted_address without triggering a search.

Before submitting a pull request, please make sure you have at least performed the following:

 - [ ] read and followed the [CONTRIBUTING.md](https://github.com/edcarroll/ng2-semantic-ui/blob/master/CONTRIBUTING.md#) guide.
 - [ ] linted, built and tested the changes locally.
 - [ ] added/updated any applicable API documentation.
 - [ ] added/updated any applicable demos.
