### PR TITLE
Fix popper namespace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6368,9 +6368,9 @@
       }
     },
     "popper.js": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.11.1.tgz",
-      "integrity": "sha512-wwp6RVokzjO4qh86qFeTw/zEw8y0uqB1U82LWTUExBDq8EJx/8svxDXVQB2jxTjRX+J+S++tQkbWnbOuOykZFw=="
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.0.tgz",
+      "integrity": "sha1-PXMTIQDIO/3F+rtHab6SX1flncI="
     },
     "portfinder": {
       "version": "1.0.13",
@@ -8676,15 +8676,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -8710,6 +8701,15 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "element-closest": "^2.0.2",
     "extend": "^3.0.1",
     "is-ua-webview": "^1.0.0",
-    "popper.js": "^1.11.1",
+    "popper.js": "^1.14.0",
     "rxjs": "^5.0.1"
   },
   "devDependencies": {

--- a/src/misc/util/services/positioning.service.ts
+++ b/src/misc/util/services/positioning.service.ts
@@ -1,13 +1,13 @@
 import { ElementRef } from "@angular/core";
-import Popper from "popper.js";
+import Popper, { Modifiers, PopperOptions, Placement, Data } from "popper.js";
 
-type PopperModifiers = Popper.Modifiers & {
+type PopperModifiers = Modifiers & {
     computeStyle?:{
         gpuAcceleration:boolean;
     };
 };
 type PopperInstance = Popper & {
-    options:Popper.PopperOptions & {
+    options:PopperOptions & {
         modifiers:PopperModifiers;
     };
 };
@@ -43,7 +43,7 @@ export interface IPositionBoundingBox {
     right:number;
 }
 
-function placementToPopper(placement:PositioningPlacement):Popper.Placement {
+function placementToPopper(placement:PositioningPlacement):Placement {
     if (!placement || placement === PositioningPlacement.Auto) {
         return "auto";
     }
@@ -67,7 +67,7 @@ function placementToPopper(placement:PositioningPlacement):Popper.Placement {
     }
 
     // Join with hyphen to create Popper compatible placement.
-    return chosenPlacement.join("-") as Popper.Placement;
+    return chosenPlacement.join("-") as Placement;
 }
 
 function popperToPlacement(popper:string):PositioningPlacement {
@@ -112,7 +112,7 @@ export class PositioningService {
     public readonly subject:ElementRef;
 
     private _popper:PopperInstance;
-    private _popperState:Popper.Data;
+    private _popperState:Data;
     private _placement:PositioningPlacement;
 
     public get placement():PositioningPlacement {
@@ -133,7 +133,7 @@ export class PositioningService {
         return popperToPlacement(this._popperState.placement);
     }
 
-    public get state():Popper.Data {
+    public get state():Data {
         return this._popperState;
     }
 


### PR DESCRIPTION
Fixes #355 

- Updated Popper.js to 1.14.0 in package.json
- Use exported Interfaces from Popper.js 