### PR TITLE
Fixed broken modals in SemanticUI 2.3

### DIFF
--- a/demo/src/app/pages/modules/modal/modal.page.html
+++ b/demo/src/app/pages/modules/modal/modal.page.html
@@ -8,15 +8,15 @@
     <h2 class="ui dividing header">Examples</h2>
 
     <p>The modal system is designed to be as flexible as possible.</p>
-    
+
     <p>Each modal has two possible outcomes, <code>approve</code> or <code>deny</code>, carrying a distinct result respectively, defined by the user.</p>
-    
+
     <p>Transitions are built in and fully customisable, with timing handled out of the box (i.e. events don't fire until the modal has finished transitioning).</p>
 
     <p>Adding the <code>autofocus</code> attribute to an element inside the modal will give it focus when the modal opens.</p>
 
     <p>Creating modals can be done in 3 distinct ways, each shown below:</p>
-    
+
     <br>
 
     <sui-tabset>

--- a/demo/src/app/pages/modules/modal/modal.page.ts
+++ b/demo/src/app/pages/modules/modal/modal.page.ts
@@ -217,7 +217,6 @@ this.modalService
     .onApprove(() => alert("User has accepted."))
     .onDeny(() => alert("User has denied."));
 `;
-
 }
 
 @Component({

--- a/demo/src/index.html
+++ b/demo/src/index.html
@@ -12,14 +12,14 @@
     <meta name="description" content="ng2-semantic-ui - Semantic UI Angular 2 Integrations">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.13/semantic.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.3.1/semantic.min.css">
     <!-- Calendar Module CSS -->
     <link rel="stylesheet" href="https://unpkg.com/semantic-ui-calendar/dist/calendar.min.css">
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.5.1/prism.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.5.1/components/prism-bash.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.5.1/components/prism-markup.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.5.1/components/prism-typescript.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.12.2/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.12.2/components/prism-bash.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.12.2/components/prism-markup.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.12.2/components/prism-typescript.min.js"></script>
 
     <!-- Web Animations Polyfill -->
     <script src="https://rawgit.com/web-animations/web-animations-js/master/web-animations.min.js"></script>

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@angular/compiler": ">= 5.0.0",
     "@angular/core": ">= 5.0.0",
     "@angular/forms": ">= 5.0.0",
-    "typescript": "^2.3.0"
+    "typescript": "^2.4.2"
   },
   "dependencies": {
     "bowser": "^1.7.2",
@@ -92,7 +92,7 @@
     "rollup-plugin-node-resolve": "~2.0.0",
     "rollup-plugin-uglify": "~1.0.1",
     "ts-node": "^5.0.1",
-    "typescript": "^2.6.2",
+    "typescript": "2.4.2",
     "web-animations-js": "^2.3.1",
     "zone.js": "^0.8.20"
   }

--- a/src/modules/modal/classes/modal-config.ts
+++ b/src/modules/modal/classes/modal-config.ts
@@ -29,6 +29,8 @@ export class ModalConfig<T, U = undefined, V = undefined> {
     public isBasic:boolean;
     // Whether the modal shows against a light background.
     public isInverted:boolean;
+    // Wheter or not the modal should be placed in the center of the page
+    public isCentered:boolean;
 
     // Whether or not the modal should always display a scrollbar.
     public mustScroll:boolean;
@@ -47,6 +49,7 @@ export class ModalConfig<T, U = undefined, V = undefined> {
         this.isFullScreen = false;
         this.isBasic = false;
         this.isInverted = false;
+        this.isCentered = true;
 
         this.mustScroll = false;
 

--- a/src/modules/modal/components/modal.ts
+++ b/src/modules/modal/components/modal.ts
@@ -11,7 +11,7 @@ import { ModalConfig, ModalSize } from "../classes/modal-config";
     selector: "sui-modal",
     template: `
 <!-- Page dimmer for modal background. -->
-<sui-dimmer class="page"
+<sui-dimmer class="page modals"
             [class.inverted]="isInverted"
             [(isDimmed)]="dimBackground"
             [isClickable]="false"
@@ -20,7 +20,7 @@ import { ModalConfig, ModalSize } from "../classes/modal-config";
             (click)="close()">
 
     <!-- Modal component, with transition component attached -->
-    <div class="ui modal"
+    <div class="ui standard modal"
          [suiTransition]="transitionController"
          [class.active]="transitionController?.isVisible"
          [class.fullscreen]="isFullScreen"
@@ -31,8 +31,6 @@ import { ModalConfig, ModalSize } from "../classes/modal-config";
          (click)="onClick($event)"
          #modal>
 
-        <!-- Configurable close icon -->
-        <i class="close icon" *ngIf="isClosable" (click)="close()"></i>
         <!-- <ng-content> so that <sui-modal> can be used as a normal component. -->
         <ng-content></ng-content>
         <!-- @ViewChild reference so we can insert elements beside this div. -->
@@ -43,6 +41,9 @@ import { ModalConfig, ModalSize } from "../classes/modal-config";
     styles: [`
 .ui.dimmer {
     overflow-y: auto;
+}
+.ui.dimmer.modals {
+    display: flex !important;
 }
 
 /* avoid .scrolling as Semantic UI adds unwanted styles. */
@@ -206,12 +207,7 @@ export class SuiModal<T, U> implements OnInit, AfterViewInit {
             templateElement.parentNode.removeChild(templateElement);
         }
 
-        // Update margin offset to center modal correctly on-screen.
         const element = this._modalElement.nativeElement as Element;
-        setTimeout(() => {
-            this._renderer.setStyle(element, "margin-top", `-${element.clientHeight / 2}px`);
-            this.updateScroll();
-        });
 
         // Focus any element with [autofocus] attribute.
         const autoFocus = element.querySelector("[autofocus]") as HTMLElement | null;

--- a/src/modules/modal/components/modal.ts
+++ b/src/modules/modal/components/modal.ts
@@ -12,7 +12,7 @@ import { ModalConfig, ModalSize } from "../classes/modal-config";
     template: `
 <!-- Page dimmer for modal background. -->
 <sui-dimmer class="page modals"
-            [class.inverted]="isInverted"
+            [ngClass]="{ 'inverted': isInverted, 'top aligned': !isCentered }"
             [(isDimmed)]="dimBackground"
             [isClickable]="false"
             [transitionDuration]="transitionDuration"
@@ -20,7 +20,7 @@ import { ModalConfig, ModalSize } from "../classes/modal-config";
             (click)="close()">
 
     <!-- Modal component, with transition component attached -->
-    <div class="ui standard modal"
+    <div class="ui modal"
          [suiTransition]="transitionController"
          [class.active]="transitionController?.isVisible"
          [class.fullscreen]="isFullScreen"
@@ -140,6 +140,10 @@ export class SuiModal<T, U> implements OnInit, AfterViewInit {
         this._isInverted = Util.DOM.parseBooleanAttribute(inverted);
     }
 
+    // Wheter or not the modal should be placed in the center of the page. When `false` it will be aligned to the top of the page
+    @Input()
+    public isCentered:boolean;
+
     public transitionController:TransitionController;
 
     // Transition to display modal with.
@@ -228,6 +232,7 @@ export class SuiModal<T, U> implements OnInit, AfterViewInit {
         this.isFullScreen = config.isFullScreen;
         this.isBasic = config.isBasic;
         this.isInverted = config.isInverted;
+        this.isCentered = config.isCentered;
 
         this.mustScroll = config.mustScroll;
 


### PR DESCRIPTION
Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/edcarroll/ng2-semantic-ui/blob/master/CONTRIBUTING.md#) guide.
 - [x] linted, built and -tested- the changes locally.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.

The new Semantic UI in version 2.3 was breaking all modals, so I fixed them in your library.
Additionally I've added bindings for the new property in the modals as well.

To actually make it working I had to adjust `package.json` config as the newest version of TypeScript was used by default and it wasn't my intention to rewrite your whole repository to make it compliant with changes in TS 2.7 and compatible tslint.

Tests were not working for me at all, so I did not change them.