### PR TITLE
fix(dropdown): Parent element accessed before initialisation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-semantic-ui",
-  "version": "0.10.0-alpha.2",
+  "version": "0.10.0-alpha.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-semantic-ui",
-  "version": "0.10.0-alpha.2",
+  "version": "0.10.0-alpha.3",
   "description": "Angular Semantic UI Components",
   "repository": {
     "type": "git",

--- a/src/modules/transition/directives/transition.ts
+++ b/src/modules/transition/directives/transition.ts
@@ -34,7 +34,7 @@ export class SuiTransition {
         return false;
     }
 
-    constructor(private _renderer:Renderer2, private _element:ElementRef, private _changeDetector:ChangeDetectorRef) {}
+    constructor(protected _renderer:Renderer2, protected _element:ElementRef, private _changeDetector:ChangeDetectorRef) {}
 
     // Initialises the controller with the injected renderer and elementRef.
     public setTransitionController(transitionController:TransitionController):void {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-semantic-ui",
-  "version": "0.10.0-alpha.2",
+  "version": "0.10.0-alpha.3",
   "description": "Angular Semantic UI Components",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes issue introduced by performance fixes that breaks the dropdown due to it attempting to access it's parent element before it's been assigned.