### PR TITLE
feat(select): Added ability to clear select

### DIFF
--- a/demo/src/app/app.component.ts
+++ b/demo/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import { Component, HostBinding } from "@angular/core";
-import { SuiPopupConfig } from "ng2-semantic-ui";
+import { SuiPopupConfig } from "../../../src";
 
 @Component({
     selector: "demo-root",

--- a/demo/src/app/app.module.ts
+++ b/demo/src/app/app.module.ts
@@ -2,7 +2,7 @@ import { BrowserModule } from "@angular/platform-browser";
 import { NgModule } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import { FormsModule } from "@angular/forms";
-import { SuiSidebarModule, SuiPopupModule } from "ng2-semantic-ui";
+import { SuiSidebarModule, SuiPopupModule } from "../../../src";
 
 import { DemoRoutingModule } from "./app.routing";
 import { DemoComponentsModule } from "./components/demo-components.module";

--- a/demo/src/app/components/demo-components.module.ts
+++ b/demo/src/app/components/demo-components.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import { RouterModule } from "@angular/router";
-import { SuiCollapseModule, SuiPopupModule } from "ng2-semantic-ui";
+import { SuiCollapseModule, SuiPopupModule } from "../../../../src";
 
 import { ApiComponent } from "./api/api.component";
 import { CodeblockComponent } from "./codeblock/codeblock.component";

--- a/demo/src/app/modals/alert.modal.ts
+++ b/demo/src/app/modals/alert.modal.ts
@@ -1,5 +1,5 @@
 import { Component } from "@angular/core";
-import { SuiModal, ComponentModalConfig, ModalSize } from "ng2-semantic-ui";
+import { Modal, ComponentModalConfig, ModalSize } from "../../../../src";
 
 interface IAlertModalContext {
     message:string;
@@ -19,7 +19,7 @@ interface IAlertModalContext {
 `
 })
 export class AlertModalComponent {
-    constructor(public modal:SuiModal<IAlertModalContext, void, void>) {}
+    constructor(public modal:Modal<IAlertModalContext, void, void>) {}
 }
 
 export class AlertModal extends ComponentModalConfig<IAlertModalContext, void, void> {

--- a/demo/src/app/modals/confirm.modal.ts
+++ b/demo/src/app/modals/confirm.modal.ts
@@ -1,5 +1,5 @@
 import { Component } from "@angular/core";
-import { SuiModal, ComponentModalConfig, ModalSize } from "ng2-semantic-ui";
+import { ComponentModalConfig, ModalSize, Modal } from "../../../../src";
 
 interface IConfirmModalContext {
     question:string;
@@ -20,7 +20,7 @@ interface IConfirmModalContext {
 `
 })
 export class ConfirmModalComponent {
-    constructor(public modal:SuiModal<IConfirmModalContext, void, void>) {}
+    constructor(public modal:Modal<IConfirmModalContext, void, void>) {}
 }
 
 export class ConfirmModal extends ComponentModalConfig<IConfirmModalContext, void, void> {

--- a/demo/src/app/modals/demo-modals.module.ts
+++ b/demo/src/app/modals/demo-modals.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from "@angular/core";
 import { CommonModule } from "@angular/common";
-import { SuiModalModule } from "ng2-semantic-ui";
+import { SuiModalModule } from "../../../../src";
 import { AlertModalComponent } from "./alert.modal";
 import { ConfirmModalComponent } from "./confirm.modal";
 

--- a/demo/src/app/pages/behaviors/localization/localization.page.ts
+++ b/demo/src/app/pages/behaviors/localization/localization.page.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy } from "@angular/core";
-import { SuiLocalizationService } from "ng2-semantic-ui";
-import locales from "ng2-semantic-ui/locales";
+import { SuiLocalizationService } from "../../../../../../src";
+import locales from "../../../../../../src/behaviors/localization/locales";
 
 const exampleTemplate = `
 <div class="ui segments">

--- a/demo/src/app/pages/demo-pages.module.ts
+++ b/demo/src/app/pages/demo-pages.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { RouterModule } from "@angular/router";
-import { SuiModule } from "ng2-semantic-ui";
+import { SuiModule } from "../../../../src";
 import { DemoComponentsModule } from "../components/demo-components.module";
 
 import { GettingStartedPage } from "./getting-started/getting-started.page";

--- a/demo/src/app/pages/modules/datepicker/datepicker.page.ts
+++ b/demo/src/app/pages/modules/datepicker/datepicker.page.ts
@@ -1,6 +1,6 @@
 import { Component } from "@angular/core";
 import { ApiDefinition } from "../../../components/api/api.component";
-import { DatepickerMode } from "ng2-semantic-ui";
+import { DatepickerMode } from "../../../../../../src";
 
 const exampleStandardTemplate = `
 <div class="ui form">

--- a/demo/src/app/pages/modules/modal/modal.page.ts
+++ b/demo/src/app/pages/modules/modal/modal.page.ts
@@ -2,8 +2,8 @@ import { Component, ViewChild } from "@angular/core";
 import { ApiDefinition } from "../../../components/api/api.component";
 import {
     SuiModalService, ModalTemplate, TemplateModalConfig, ComponentModalConfig,
-    ModalSize, SuiModal
-} from "ng2-semantic-ui";
+    ModalSize, Modal
+} from "../../../../../../src";
 import { AlertModal } from "../../../modals/alert.modal";
 
 const exampleTemplateModalTemplate = `
@@ -266,7 +266,7 @@ interface IConfirmModalContext {
     template: exampleComponentModalTemplate
 })
 export class ConfirmModalComponent {
-    constructor(public modal:SuiModal<IConfirmModalContext, void, void>) {}
+    constructor(public modal:Modal<IConfirmModalContext, void, void>) {}
 }
 
 export class ConfirmModal extends ComponentModalConfig<IConfirmModalContext, void, void> {

--- a/demo/src/app/pages/modules/popup/popup.page.ts
+++ b/demo/src/app/pages/modules/popup/popup.page.ts
@@ -1,6 +1,6 @@
 import { Component, Input } from "@angular/core";
 import { ApiDefinition } from "../../../components/api/api.component";
-import { SuiPopupConfig } from "ng2-semantic-ui";
+import { SuiPopupConfig } from "../../../../../../src";
 
 const exampleStandardTemplate = `
 <button class="ui green icon button" suiPopup popupHeader="Example" popupText="This is an example popup">

--- a/demo/src/app/pages/modules/search/search.page.ts
+++ b/demo/src/app/pages/modules/search/search.page.ts
@@ -1,6 +1,6 @@
 import { Component } from "@angular/core";
 import { ApiDefinition } from "../../../components/api/api.component";
-import { SuiModalService } from "ng2-semantic-ui";
+import { SuiModalService } from "../../../../../../src";
 import { AlertModal } from "../../../modals/alert.modal";
 
 const exampleStandardTemplate = `

--- a/demo/src/app/pages/modules/select/select.page.html
+++ b/demo/src/app/pages/modules/select/select.page.html
@@ -39,6 +39,14 @@
         <example-select-variations result></example-select-variations>
     </demo-example>
 
+    <demo-example [code]="exampleClearableTemplate">
+        <div info>
+            <h4 class="ui header">Clearable select</h4>
+            <p>A select can have a "clear" icon to reset the selected value. It's useful if you want to use a <code>SuiSelect</code> as filter</p>
+        </div>
+        <example-clearable-select result></example-clearable-select>
+    </demo-example>
+
     <demo-example [code]="exampleInMenuSearchTemplate">
         <div info>
             <h4 class="ui header">Search In-Menu</h4>

--- a/demo/src/app/pages/modules/select/select.page.ts
+++ b/demo/src/app/pages/modules/select/select.page.ts
@@ -91,6 +91,18 @@ const exampleVariationsTemplate = `
 </div>
 `;
 
+const exampleClearableTemplate = `
+<sui-select class="selection"
+            [(ngModel)]="selectedOption"
+            [options]="filters"
+            [isClearable]="true"
+            #select>
+    <sui-select-option *ngFor="let option of select.filteredOptions"
+                       [value]="option">
+    </sui-select-option>
+</sui-select>
+`;
+
 const exampleInMenuSearchTemplate = `
 <sui-multi-select [(ngModel)]="selected"
                   [options]="options"
@@ -219,6 +231,12 @@ export class SelectPage {
                     name: "isSearchable",
                     type: "boolean",
                     description: "Sets whether the multi select is searchable.",
+                    defaultValue: "false"
+                },
+                {
+                    name: "isСlearable",
+                    type: "boolean",
+                    description: "Sets whether the select is clearable.",
                     defaultValue: "false"
                 },
                 {
@@ -408,6 +426,7 @@ export class SelectPage {
     ];
     public exampleStandardTemplate:string = exampleStandardTemplate;
     public exampleVariationsTemplate:string = exampleVariationsTemplate;
+    public exampleClearableTemplate:string = exampleClearableTemplate;
     public exampleInMenuSearchTemplate:string = exampleInMenuSearchTemplate;
     public exampleTemplateTemplate:string = exampleTemplateTemplate;
     public formatterCode:string = `
@@ -469,6 +488,15 @@ export class SelectExampleVariations {
 }
 
 @Component({
+    selector: "example-clearable-select",
+    template: exampleClearableTemplate
+})
+export class SelectClearableExample {
+    public selectedOption:string;
+    public filters:string[] = ["Important", "Announcement", "Discussion"];
+}
+
+@Component({
     selector: "example-select-in-menu-search",
     template: exampleInMenuSearchTemplate
 })
@@ -520,6 +548,7 @@ export const SelectPageComponents = [
 
     SelectExampleStandard,
     SelectExampleVariations,
+    SelectClearableExample,
     SelectExampleInMenuSearch,
     SelectExampleTemplate,
     SelectExampleLookupSearch

--- a/demo/src/app/pages/modules/tabs/tabs.page.ts
+++ b/demo/src/app/pages/modules/tabs/tabs.page.ts
@@ -1,6 +1,6 @@
 import { Component } from "@angular/core";
 import { ApiDefinition } from "../../../components/api/api.component";
-import { SuiModalService } from "ng2-semantic-ui";
+import { SuiModalService } from "../../../../../../src";
 import { AlertModal } from "../../../modals/alert.modal";
 
 const exampleStandardTemplate = `

--- a/demo/src/app/pages/modules/transition/transition.page.ts
+++ b/demo/src/app/pages/modules/transition/transition.page.ts
@@ -1,5 +1,5 @@
 import { Component } from "@angular/core";
-import { SuiTransition, Transition, TransitionDirection, TransitionController } from "ng2-semantic-ui";
+import { SuiTransition, Transition, TransitionDirection, TransitionController } from "../../../../../../src";
 import { ApiDefinition } from "../../../components/api/api.component";
 
 const exampleStandardTemplate = `


### PR DESCRIPTION
Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/edcarroll/ng2-semantic-ui/blob/master/CONTRIBUTING.md#) guide.
 - [x] linted, built and tested the changes locally.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.

This PR adds a `isClearable` property to the `SuiSelect` to allow the ability to deselect an option. 
It can be useful if you are using a select as a filter and want the ability to reset it.

Here the example:
![clearable-select](https://user-images.githubusercontent.com/20536879/44956487-cd424080-aecd-11e8-8a14-c4b60f9afd5b.gif)
