### PR TITLE
Fix: Handle non-Date objects in DateUtil.clone

### DIFF
--- a/src/misc/util/helpers/date.ts
+++ b/src/misc/util/helpers/date.ts
@@ -176,6 +176,8 @@ export const DateUtil = {
     },
 
     clone(date:Date):Date {
-        return new Date(date.getTime());
+        let parsedDate = date;
+        if (typeof parsedDate === "string") parsedDate = new Date(Date.parse(parsedDate));
+        return new Date(parsedDate.getTime());
     }
 };


### PR DESCRIPTION
The DateUtil.clone function previously relied on date.getTime(), which would throw an error if date was not a valid Date object. This could occur if a string, number, or other unexpected data type was passed to the function.

This commit makes DateUtil.clone more robust by handling non-Date objects. The function now checks if the input date is a string. If so, it attempts to parse the string into a Date object using Date.parse(). This allows the function to handle date strings correctly.

This change prevents runtime errors and improves the reliability of DateUtil.clone when dealing with various input types.